### PR TITLE
Add draft v1.2.x schemas

### DIFF
--- a/openapi/v1.1.0/optimade.json
+++ b/openapi/v1.1.0/optimade.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTIMADE API",
-    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.19.1) v0.19.1.",
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.19.5) v0.19.5.",
     "version": "1.1.0"
   },
   "paths": {
@@ -301,10 +301,8 @@
             "required": false,
             "schema": {
               "title": "Page Number",
-              "minimum": 1.0,
               "type": "integer",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
-              "default": 0
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
             },
             "name": "page_number",
             "in": "query"
@@ -560,10 +558,8 @@
             "required": false,
             "schema": {
               "title": "Page Number",
-              "minimum": 1.0,
               "type": "integer",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
-              "default": 0
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
             },
             "name": "page_number",
             "in": "query"
@@ -984,10 +980,8 @@
             "required": false,
             "schema": {
               "title": "Page Number",
-              "minimum": 1.0,
               "type": "integer",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
-              "default": 0
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
             },
             "name": "page_number",
             "in": "query"
@@ -1359,8 +1353,8 @@
               }
             },
             "description": "Index of the sites (0-based) that belong to each group for each assembly.\n\n- **Examples**:\n    - `[[1], [2]]`: two groups, one with the second site, one with the third.\n    - `[[1,2], [3]]`: one group with the second and third site, one with the fourth.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
           },
           "group_probabilities": {
             "title": "Group Probabilities",
@@ -1369,8 +1363,8 @@
               "type": "number"
             },
             "description": "Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\nIt SHOULD sum to one.\nSee below for examples of how to specify the probability of the occurrence of a vacancy.\nThe possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
           }
         },
         "description": "A description of groups of sites that are statistically correlated.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n      Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n      The second group is formed by the fourth site. Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n      30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent)."
@@ -1591,7 +1585,7 @@
           "dictionary",
           "unknown"
         ],
-        "description": "Optimade Data Types\n\nSee the section \"Data types\" in the OPTIMADE API specification for more information."
+        "description": "Optimade Data Types\n\n    See the section \"Data types\" in the OPTIMADE API specification for more information.\n    "
       },
       "EntryInfoProperty": {
         "title": "EntryInfoProperty",
@@ -1773,15 +1767,15 @@
             "title": "Id",
             "type": "string",
             "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "type": {
             "title": "Type",
             "type": "string",
             "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "links": {
             "title": "Links",
@@ -1833,16 +1827,16 @@
             "title": "Immutable Id",
             "type": "string",
             "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
             "format": "date-time",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           }
         },
         "description": "Contains key-value pairs representing the entry's properties."
@@ -2241,8 +2235,8 @@
             "title": "Id",
             "type": "string",
             "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "type": {
             "title": "Type",
@@ -2540,22 +2534,22 @@
             "title": "Name",
             "type": "string",
             "description": "Full name of the person, REQUIRED.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
           },
           "firstname": {
             "title": "Firstname",
             "type": "string",
             "description": "First name of the person.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "lastname": {
             "title": "Lastname",
             "type": "string",
             "description": "Last name of the person.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           }
         },
         "description": "A person, i.e., an author, editor or other."
@@ -2657,8 +2651,8 @@
             "title": "Id",
             "type": "string",
             "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "type": {
             "title": "Type",
@@ -2666,8 +2660,8 @@
             "type": "string",
             "description": "The name of the type of an entry.\n- **Type**: string.\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type <type> and ID <id> MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n- **Example**: `\"structures\"`",
             "default": "references",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "links": {
             "title": "Links",
@@ -2713,16 +2707,16 @@
             "title": "Immutable Id",
             "type": "string",
             "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
             "format": "date-time",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "authors": {
             "title": "Authors",
@@ -2731,8 +2725,8 @@
               "$ref": "#/components/schemas/Person"
             },
             "description": "List of person objects containing the authors of the reference.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "editors": {
             "title": "Editors",
@@ -2741,15 +2735,15 @@
               "$ref": "#/components/schemas/Person"
             },
             "description": "List of person objects containing the editors of the reference.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "doi": {
             "title": "Doi",
             "type": "string",
             "description": "The digital object identifier of the reference.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "url": {
             "title": "Url",
@@ -2758,162 +2752,162 @@
             "type": "string",
             "description": "The URL of the reference.",
             "format": "uri",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "address": {
             "title": "Address",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "annote": {
             "title": "Annote",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "booktitle": {
             "title": "Booktitle",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "chapter": {
             "title": "Chapter",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "crossref": {
             "title": "Crossref",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "edition": {
             "title": "Edition",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "howpublished": {
             "title": "Howpublished",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "institution": {
             "title": "Institution",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "journal": {
             "title": "Journal",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "key": {
             "title": "Key",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "month": {
             "title": "Month",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "note": {
             "title": "Note",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "number": {
             "title": "Number",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "organization": {
             "title": "Organization",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "pages": {
             "title": "Pages",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "publisher": {
             "title": "Publisher",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "school": {
             "title": "School",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "series": {
             "title": "Series",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "title": {
             "title": "Title",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "bib_type": {
             "title": "Bib Type",
             "type": "string",
             "description": "Type of the reference, corresponding to the **type** property in the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "volume": {
             "title": "Volume",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "year": {
             "title": "Year",
             "type": "string",
             "description": "Meaning of property matches the BiBTeX specification.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           }
         },
         "description": "Model that stores the attributes of a reference.\n\nMany properties match the meaning described in the\n[BibTeX specification](http://bibtexml.sourceforge.net/btxdoc.pdf)."
@@ -3335,8 +3329,8 @@
             "title": "Name",
             "type": "string",
             "description": "Gives the name of the species; the **name** value MUST be unique in the `species` list.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
           },
           "chemical_symbols": {
             "title": "Chemical Symbols",
@@ -3345,8 +3339,8 @@
               "type": "string"
             },
             "description": "MUST be a list of strings of all chemical elements composing this species. Each item of the list MUST be one of the following:\n\n- a valid chemical-element symbol, or\n- the special value `\"X\"` to represent a non-chemical element, or\n- the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\nIf any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
           },
           "concentration": {
             "title": "Concentration",
@@ -3355,8 +3349,8 @@
               "type": "number"
             },
             "description": "MUST be a list of floats, with same length as `chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species. The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n- Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n- Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\nNote that concentrations are uncorrelated between different site (even of the same species).",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
           },
           "mass": {
             "title": "Mass",
@@ -3365,16 +3359,16 @@
               "type": "number"
             },
             "description": "If present MUST be a list of floats expressed in a.m.u.\nElements denoting vacancies MUST have masses equal to 0.",
-            "x-optimade-queryable": "optional",
             "x-optimade-unit": "a.m.u.",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "original_name": {
             "title": "Original Name",
             "type": "string",
             "description": "Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\nNote: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "attached": {
             "title": "Attached",
@@ -3383,8 +3377,8 @@
               "type": "string"
             },
             "description": "If provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "nattached": {
             "title": "Nattached",
@@ -3393,8 +3387,8 @@
               "type": "integer"
             },
             "description": "If provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           }
         },
         "description": "A list describing the species of the sites of this structure.\n\nSpecies can represent pure chemical elements, virtual-crystal atoms representing a\nstatistical occupation of a given site by multiple chemical elements, and/or a\nlocation to which there are attached atoms, i.e., atoms whose precise location are\nunknown beyond that they are attached to that position (frequently used to indicate\nhydrogen atoms attached to another element, e.g., a carbon with three attached\nhydrogens might represent a methyl group, -CH3).\n\n- **Examples**:\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - `[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": [0.0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - `[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - `[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.\n    - `[ {\"name\": \"CH3\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"attached\": [\"H\"], \"nattached\": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms."
@@ -3463,8 +3457,8 @@
             "title": "Id",
             "type": "string",
             "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "type": {
             "title": "Type",
@@ -3472,8 +3466,8 @@
             "type": "string",
             "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Examples**:\n    - `\"structures\"`",
             "default": "structures",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "links": {
             "title": "Links",
@@ -3533,8 +3527,8 @@
             "title": "Immutable Id",
             "type": "string",
             "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
           },
           "last_modified": {
             "title": "Last Modified",
@@ -3542,8 +3536,8 @@
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
             "format": "date-time",
             "nullable": true,
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "elements": {
             "title": "Elements",
@@ -3553,16 +3547,16 @@
             },
             "description": "The chemical symbols of the different elements present in the structure.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The strings are the chemical symbols, i.e., either a single uppercase letter or an uppercase letter followed by a number of lowercase letters.\n    - The order MUST be alphabetical.\n    - MUST refer to the same elements in the same order, and therefore be of the same length, as `elements_ratios`, if the latter is provided.\n    - Note: This property SHOULD NOT contain the string \"X\" to indicate non-chemical elements or \"vacancy\" to indicate vacancies (in contrast to the field `chemical_symbols` for the `species` property).\n\n- **Examples**:\n    - `[\"Si\"]`\n    - `[\"Al\",\"O\",\"Si\"]`\n\n- **Query examples**:\n    - A filter that matches all records of structures that contain Si, Al **and** O, and possibly other elements: `elements HAS ALL \"Si\", \"Al\", \"O\"`.\n    - To match structures with exactly these three elements, use `elements HAS ALL \"Si\", \"Al\", \"O\" AND elements LENGTH 3`.\n    - Note: length queries on this property can be equivalently formulated by filtering on the `nelements`_ property directly.",
             "nullable": true,
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "nelements": {
             "title": "Nelements",
             "type": "integer",
             "description": "Number of different elements in the structure as an integer.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - MUST be equal to the lengths of the list properties `elements` and `elements_ratios`, if they are provided.\n\n- **Examples**:\n    - `3`\n\n- **Querying**:\n    - Note: queries on this property can equivalently be formulated using `elements LENGTH`.\n    - A filter that matches structures that have exactly 4 elements: `nelements=4`.\n    - A filter that matches structures that have between 2 and 7 elements: `nelements>=2 AND nelements<=7`.",
             "nullable": true,
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "elements_ratios": {
             "title": "Elements Ratios",
@@ -3572,16 +3566,16 @@
             },
             "description": "Relative proportions of different elements in the structure.\n\n- **Type**: list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - Composed by the proportions of elements in the structure as a list of floating point numbers.\n    - The sum of the numbers MUST be 1.0 (within floating point accuracy)\n    - MUST refer to the same elements in the same order, and therefore be of the same length, as `elements`, if the latter is provided.\n\n- **Examples**:\n    - `[1.0]`\n    - `[0.3333333333333333, 0.2222222222222222, 0.4444444444444444]`\n\n- **Query examples**:\n    - Note: Useful filters can be formulated using the set operator syntax for correlated values.\n      However, since the values are floating point values, the use of equality comparisons is generally inadvisable.\n    - OPTIONAL: a filter that matches structures where approximately 1/3 of the atoms in the structure are the element Al is: `elements:elements_ratios HAS ALL \"Al\":>0.3333, \"Al\":<0.3334`.",
             "nullable": true,
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "chemical_formula_descriptive": {
             "title": "Chemical Formula Descriptive",
             "type": "string",
             "description": "The chemical formula for a structure as a string in a form chosen by the API implementation.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The chemical formula is given as a string consisting of properly capitalized element symbols followed by integers or decimal numbers, balanced parentheses, square, and curly brackets `(`,`)`, `[`,`]`, `{`, `}`, commas, the `+`, `-`, `:` and `=` symbols. The parentheses are allowed to be followed by a number. Spaces are allowed anywhere except within chemical symbols. The order of elements and any groupings indicated by parentheses or brackets are chosen freely by the API implementation.\n    - The string SHOULD be arithmetically consistent with the element ratios in the `chemical_formula_reduced` property.\n    - It is RECOMMENDED, but not mandatory, that symbols, parentheses and brackets, if used, are used with the meanings prescribed by [IUPAC's Nomenclature of Organic Chemistry](https://www.qmul.ac.uk/sbcs/iupac/bibliog/blue.html).\n\n- **Examples**:\n    - `\"(H2O)2 Na\"`\n    - `\"NaCl\"`\n    - `\"CaCO3\"`\n    - `\"CCaO3\"`\n    - `\"(CH3)3N+ - [CH2]2-OH = Me3N+ - CH2 - CH2OH\"`\n\n- **Query examples**:\n    - Note: the free-form nature of this property is likely to make queries on it across different databases inconsistent.\n    - A filter that matches an exactly given formula: `chemical_formula_descriptive=\"(H2O)2 Na\"`.\n    - A filter that does a partial match: `chemical_formula_descriptive CONTAINS \"H2O\"`.",
             "nullable": true,
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "chemical_formula_reduced": {
             "title": "Chemical Formula Reduced",
@@ -3589,16 +3583,16 @@
             "type": "string",
             "description": "The reduced chemical formula for a structure as a string with element symbols and integer chemical proportion numbers.\nThe proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property.\n      However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n      Intricate queries on formula components are instead suggested to be formulated using set-type filter operators on the multi valued `elements` and `elements_ratios` properties.\n    - Element symbols MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in alphabetical order, followed by their integer chemical proportion number.\n    - For structures with no partial occupation, the chemical proportion numbers are the smallest integers for which the chemical proportion is exactly correct.\n    - For structures with partial occupation, the chemical proportion numbers are integers that within reasonable approximation indicate the correct chemical proportions. The precise details of how to perform the rounding is chosen by the API implementation.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2NaO\"`\n    - `\"ClNa\"`\n    - `\"CCaO3\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_reduced=\"H2NaO\"`.",
             "nullable": true,
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "chemical_formula_hill": {
             "title": "Chemical Formula Hill",
             "pattern": "^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
             "type": "string",
             "description": "The chemical formula for a structure in [Hill form](https://dx.doi.org/10.1021/ja02046a005) with element symbols followed by integer chemical proportion numbers. The proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, only a subset of the filter features MAY be supported.\n    - The overall scale factor of the chemical proportions is chosen such that the resulting values are integers that indicate the most chemically relevant unit of which the system is composed.\n      For example, if the structure is a repeating unit cell with four hydrogens and four oxygens that represents two hydroperoxide molecules, `chemical_formula_hill` is `\"H2O2\"` (i.e., not `\"HO\"`, nor `\"H4O4\"`).\n    - If the chemical insight needed to ascribe a Hill formula to the system is not present, the property MUST be handled as unset.\n    - Element symbols MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in [Hill order](https://dx.doi.org/10.1021/ja02046a005), followed by their integer chemical proportion number.\n      Hill order means: if carbon is present, it is placed first, and if also present, hydrogen is placed second.\n      After that, all other elements are ordered alphabetically.\n      If carbon is not present, all elements are ordered alphabetically.\n    - If the system has sites with partial occupation and the total occupations of each element do not all sum up to integers, then the Hill formula SHOULD be handled as unset.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2O2\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_hill=\"H2O2\"`.",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "chemical_formula_anonymous": {
             "title": "Chemical Formula Anonymous",
@@ -3606,8 +3600,8 @@
             "type": "string",
             "description": "The anonymous formula is the `chemical_formula_reduced`, but where the elements are instead first ordered by their chemical proportion number, and then, in order left to right, replaced by anonymous symbols A, B, C, ..., Z, Aa, Ba, ..., Za, Ab, Bb, ... and so on.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property.\n      However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n\n- **Examples**:\n    - `\"A2B\"`\n    - `\"A42B42C16D12E10F9G5\"`\n\n- **Querying**:\n    - A filter that matches an exactly given formula is `chemical_formula_anonymous=\"A2B\"`.",
             "nullable": true,
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "dimension_types": {
             "title": "Dimension Types",
@@ -3619,16 +3613,16 @@
             },
             "description": "List of three integers.\nFor each of the three directions indicated by the three lattice vectors (see property `lattice_vectors`), this list indicates if the direction is periodic (value `1`) or non-periodic (value `0`).\nNote: the elements in this list each refer to the direction of the corresponding entry in `lattice_vectors` and *not* the Cartesian x, y, z directions.\n\n- **Type**: list of integers.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n    - MUST be a list of length 3.\n    - Each integer element MUST assume only the value 0 or 1.\n\n- **Examples**:\n    - For a molecule: `[0, 0, 0]`\n    - For a wire along the direction specified by the third lattice vector: `[0, 0, 1]`\n    - For a 2D surface/slab, periodic on the plane defined by the first and third lattice vectors: `[1, 0, 1]`\n    - For a bulk 3D system: `[1, 1, 1]`",
             "nullable": true,
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
           },
           "nperiodic_dimensions": {
             "title": "Nperiodic Dimensions",
             "type": "integer",
             "description": "An integer specifying the number of periodic dimensions in the structure, equivalent to the number of non-zero entries in `dimension_types`.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The integer value MUST be between 0 and 3 inclusive and MUST be equal to the sum of the items in the `dimension_types` property.\n    - This property only reflects the treatment of the lattice vectors provided for the structure, and not any physical interpretation of the dimensionality of its contents.\n\n- **Examples**:\n    - `2` should be indicated in cases where `dimension_types` is any of `[1, 1, 0]`, `[1, 0, 1]`, `[0, 1, 1]`.\n\n- **Query examples**:\n    - Match only structures with exactly 3 periodic dimensions: `nperiodic_dimensions=3`\n    - Match all structures with 2 or fewer periodic dimensions: `nperiodic_dimensions<=2`",
             "nullable": true,
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "lattice_vectors": {
             "title": "Lattice Vectors",
@@ -3645,9 +3639,9 @@
             },
             "description": "The three lattice vectors in Cartesian coordinates, in \u00e5ngstr\u00f6m (\u00c5).\n\n- **Type**: list of list of floats or unknown values.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST be a list of three vectors *a*, *b*, and *c*, where each of the vectors MUST BE a list of the vector's coordinates along the x, y, and z Cartesian coordinates.\n      (Therefore, the first index runs over the three lattice vectors and the second index runs over the x, y, z Cartesian coordinates).\n    - For databases that do not define an absolute Cartesian system (e.g., only defining the length and angles between vectors), the first lattice vector SHOULD be set along *x* and the second on the *xy*-plane.\n    - MUST always contain three vectors of three coordinates each, independently of the elements of property `dimension_types`.\n      The vectors SHOULD by convention be chosen so the determinant of the `lattice_vectors` matrix is different from zero.\n      The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.\n    - The coordinates of the lattice vectors of non-periodic dimensions (i.e., those dimensions for which `dimension_types` is `0`) MAY be given as a list of all `null` values.\n        If a lattice vector contains the value `null`, all coordinates of that lattice vector MUST be `null`.\n\n- **Examples**:\n    - `[[4.0,0.0,0.0],[0.0,4.0,0.0],[0.0,1.0,4.0]]` represents a cell, where the first vector is `(4, 0, 0)`, i.e., a vector aligned along the `x` axis of length 4 \u00c5; the second vector is `(0, 4, 0)`; and the third vector is `(0, 1, 4)`.",
             "nullable": true,
-            "x-optimade-queryable": "optional",
             "x-optimade-unit": "\u00c5",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
           },
           "cartesian_site_positions": {
             "title": "Cartesian Site Positions",
@@ -3662,17 +3656,17 @@
             },
             "description": "Cartesian positions of each site in the structure.\nA site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the `species_at_sites` property, and the species themselves are described in the `species` property.\n\n- **Type**: list of list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - It MUST be a list of length equal to the number of sites in the structure, where every element is a list of the three Cartesian coordinates of a site expressed as float values in the unit angstrom (\u00c5).\n    - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`).\n\n- **Examples**:\n    - `[[0,0,0],[0,0,2]]` indicates a structure with two sites, one sitting at the origin and one along the (positive) *z*-axis, 2 \u00c5 away from the origin.",
             "nullable": true,
-            "x-optimade-queryable": "optional",
             "x-optimade-unit": "\u00c5",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
           },
           "nsites": {
             "title": "Nsites",
             "type": "integer",
             "description": "An integer specifying the length of the `cartesian_site_positions` property.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `42`\n\n- **Query examples**:\n    - Match only structures with exactly 4 sites: `nsites=4`\n    - Match structures that have between 2 and 7 sites: `nsites>=2 AND nsites<=7`",
             "nullable": true,
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           },
           "species": {
             "title": "Species",
@@ -3682,8 +3676,8 @@
             },
             "description": "A list describing the species of the sites of this structure.\nSpecies can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (frequently used to indicate hydrogen atoms attached to another element, e.g., a carbon with three attached hydrogens might represent a methyl group, -CH3).\n\n- **Type**: list of dictionary with keys:\n    - `name`: string (REQUIRED)\n    - `chemical_symbols`: list of strings (REQUIRED)\n    - `concentration`: list of float (REQUIRED)\n    - `attached`: list of strings (REQUIRED)\n    - `nattached`: list of integers (OPTIONAL)\n    - `mass`: list of floats (OPTIONAL)\n    - `original_name`: string (OPTIONAL).\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - Each list member MUST be a dictionary with the following keys:\n        - **name**: REQUIRED; gives the name of the species; the **name** value MUST be unique in the `species` list;\n        - **chemical_symbols**: REQUIRED; MUST be a list of strings of all chemical elements composing this species.\n          Each item of the list MUST be one of the following:\n            - a valid chemical-element symbol, or\n            - the special value `\"X\"` to represent a non-chemical element, or\n            - the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\n          If any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`.\n\n        - **concentration**: REQUIRED; MUST be a list of floats, with same length as `chemical_symbols`.\n          The numbers represent the relative concentration of the corresponding chemical symbol in this species.\n          The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n            - Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n            - Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\n            Note that concentrations are uncorrelated between different sites (even of the same species).\n\n        - **attached**: OPTIONAL; if provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element.\n\n        - **nattached**: OPTIONAL; if provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the `attached` key.\n\n          The implementation MUST include either both or none of the `attached` and `nattached` keys, and if they are provided, they MUST be of the same length.\n          Furthermore, if they are provided, the `structure_features` property MUST include the string `site_attachments`.\n\n        - **mass**: OPTIONAL. If present MUST be a list of floats, with the same length as `chemical_symbols`, providing element masses expressed in a.m.u.\n          Elements denoting vacancies MUST have masses equal to 0.\n\n        - **original_name**: OPTIONAL. Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\n          Note: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.\n\n          The main use of this field is for source databases that use species names, containing characters that are not allowed (see description of the list property `species_at_sites`).\n\n    - For systems that have only species formed by a single chemical symbol, and that have at most one species per chemical symbol, SHOULD use the chemical symbol as species name (e.g., `\"Ti\"` for titanium, `\"O\"` for oxygen, etc.)\n      However, note that this is OPTIONAL, and client implementations MUST NOT assume that the key corresponds to a chemical symbol, nor assume that if the species name is a valid chemical symbol, that it represents a species with that chemical symbol.\n      This means that a species `{\"name\": \"C\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]}` is valid and represents a titanium species (and *not* a carbon species).\n    - It is NOT RECOMMENDED that a structure includes species that do not have at least one corresponding site.\n\n- **Examples**:\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - `[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": [0.0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - `[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - `[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.\n    - `[ {\"name\": \"CH3\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"attached\": [\"H\"], \"nattached\": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.",
             "nullable": true,
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
           },
           "species_at_sites": {
             "title": "Species At Sites",
@@ -3693,8 +3687,8 @@
             },
             "description": "Name of the species at each site (where values for sites are specified with the same order of the property `cartesian_site_positions`).\nThe properties of the species are found in the property `species`.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST have length equal to the number of sites in the structure (first dimension of the list property `cartesian_site_positions`).\n    - Each species name mentioned in the `species_at_sites` list MUST be described in the list property `species` (i.e. for each value in the `species_at_sites` list there MUST exist exactly one dictionary in the `species` list with the `name` attribute equal to the corresponding `species_at_sites` value).\n    - Each site MUST be associated only to a single species.\n      **Note**: However, species can represent mixtures of atoms, and multiple species MAY be defined for the same chemical element.\n      This latter case is useful when different atoms of the same type need to be grouped or distinguished, for instance in simulation codes to assign different initial spin states.\n\n- **Examples**:\n    - `[\"Ti\",\"O2\"]` indicates that the first site is hosting a species labeled `\"Ti\"` and the second a species labeled `\"O2\"`.\n    - `[\"Ac\", \"Ac\", \"Ag\", \"Ir\"]` indicating the first two sites contains the `\"Ac\"` species, while the third and fourth sites contain the `\"Ag\"` and `\"Ir\"` species, respectively.",
             "nullable": true,
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
           },
           "assemblies": {
             "title": "Assemblies",
@@ -3703,8 +3697,8 @@
               "$ref": "#/components/schemas/Assembly"
             },
             "description": "A description of groups of sites that are statistically correlated.\n\n- **Type**: list of dictionary with keys:\n    - `sites_in_groups`: list of list of integers (REQUIRED)\n    - `group_probabilities`: list of floats (REQUIRED)\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - The property SHOULD be `null` for entries that have no partial occupancies.\n    - If present, the correct flag MUST be set in the list `structure_features`.\n    - Client implementations MUST check its presence (as its presence changes the interpretation of the structure).\n    - If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have the following two keys:\n        - **sites_in_groups**: Index of the sites (0-based) that belong to each group for each assembly.\n\n            Example: `[[1], [2]]`: two groups, one with the second site, one with the third.\n            Example: `[[1,2], [3]]`: one group with the second and third site, one with the fourth.\n\n        - **group_probabilities**: Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\n            It SHOULD sum to one.\n            See below for examples of how to specify the probability of the occurrence of a vacancy.\n            The possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.\n\n    - If a site is not present in any group, it means that it is present with 100 % probability (as if no assembly was specified).\n    - A site MUST NOT appear in more than one group.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n        Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n        The second group is formed by the fourth site.\n        Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n        30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent).\n\n- **Notes**:\n    - Assemblies are essential to represent, for instance, the situation where an atom can statistically occupy two different positions (sites).\n\n    - By defining groups, it is possible to represent, e.g., the case where a functional molecule (and not just one atom) is either present or absent (or the case where it it is present in two conformations)\n\n    - Considerations on virtual alloys and on vacancies: In the special case of a virtual alloy, these specifications allow two different, equivalent ways of specifying them.\n        For instance, for a site at the origin with 30 % probability of being occupied by Si, 50 % probability of being occupied by Ge, and 20 % of being a vacancy, the following two representations are possible:\n\n        - Using a single species:\n            ```json\n            {\n              \"cartesian_site_positions\": [[0,0,0]],\n              \"species_at_sites\": [\"SiGe-vac\"],\n              \"species\": [\n              {\n                \"name\": \"SiGe-vac\",\n                \"chemical_symbols\": [\"Si\", \"Ge\", \"vacancy\"],\n                \"concentration\": [0.3, 0.5, 0.2]\n              }\n              ]\n              // ...\n            }\n            ```\n\n        - Using multiple species and the assemblies:\n            ```json\n            {\n              \"cartesian_site_positions\": [ [0,0,0], [0,0,0], [0,0,0] ],\n              \"species_at_sites\": [\"Si\", \"Ge\", \"vac\"],\n              \"species\": [\n                { \"name\": \"Si\", \"chemical_symbols\": [\"Si\"], \"concentration\": [1.0] },\n                { \"name\": \"Ge\", \"chemical_symbols\": [\"Ge\"], \"concentration\": [1.0] },\n                { \"name\": \"vac\", \"chemical_symbols\": [\"vacancy\"], \"concentration\": [1.0] }\n              ],\n              \"assemblies\": [\n                {\n              \"sites_in_groups\": [ [0], [1], [2] ],\n              \"group_probabilities\": [0.3, 0.5, 0.2]\n                }\n              ]\n              // ...\n            }\n            ```\n\n    - It is up to the database provider to decide which representation to use, typically depending on the internal format in which the structure is stored.\n        However, given a structure identified by a unique ID, the API implementation MUST always provide the same representation for it.\n\n    - The probabilities of occurrence of different assemblies are uncorrelated.\n        So, for instance in the following case with two assemblies:\n        ```json\n        {\n          \"assemblies\": [\n            {\n              \"sites_in_groups\": [ [0], [1] ],\n              \"group_probabilities\": [0.2, 0.8],\n            },\n            {\n              \"sites_in_groups\": [ [2], [3] ],\n              \"group_probabilities\": [0.3, 0.7]\n            }\n          ]\n        }\n        ```\n\n        Site 0 is present with a probability of 20 % and site 1 with a probability of 80 %. These two sites are correlated (either site 0 or 1 is present). Similarly, site 2 is present with a probability of 30 % and site 3 with a probability of 70 %.\n        These two sites are correlated (either site 2 or 3 is present).\n        However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2*0.3 = 6 % probability; the pair (0, 3) with 0.2*0.7 = 14 % probability; the pair (1, 2) with 0.8*0.3 = 24 % probability; and the pair (1, 3) with 0.8*0.7 = 56 % probability).",
-            "x-optimade-queryable": "optional",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
           },
           "structure_features": {
             "title": "Structure Features",
@@ -3713,8 +3707,8 @@
               "$ref": "#/components/schemas/StructureFeatures"
             },
             "description": "A list of strings that flag which special features are used by the structure.\n\n- **Type**: list of strings\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property.\n    Filters on the list MUST support all mandatory HAS-type queries.\n    Filter operators for comparisons on the string components MUST support equality, support for other comparison operators are OPTIONAL.\n    - MUST be an empty list if no special features are used.\n    - MUST be sorted alphabetically.\n    - If a special feature listed below is used, the list MUST contain the corresponding string.\n    - If a special feature listed below is not used, the list MUST NOT contain the corresponding string.\n    - **List of strings used to indicate special structure features**:\n        - `disorder`: this flag MUST be present if any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element.\n        - `implicit_atoms`: this flag MUST be present if the structure contains atoms that are not assigned to sites via the property `species_at_sites` (e.g., because their positions are unknown).\n           When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`, `species` and `assemblies` properties.\n        - `site_attachments`: this flag MUST be present if any one entry in the `species` list includes `attached` and `nattached`.\n        - `assemblies`: this flag MUST be present if the property `assemblies` is present.\n\n- **Examples**: A structure having implicit atoms and using assemblies: `[\"assemblies\", \"implicit_atoms\"]`",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           }
         },
         "description": "This class contains the Field for the attributes used to represent a structure, e.g. unit cell, atoms, positions."

--- a/openapi/v1.1.0/optimade.json
+++ b/openapi/v1.1.0/optimade.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTIMADE API",
-    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.16.0) v0.16.0.",
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.19.1) v0.19.1.",
     "version": "1.1.0"
   },
   "paths": {
@@ -17,7 +17,7 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/InfoResponse"
                 }
@@ -27,7 +27,7 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -37,7 +37,7 @@
           "403": {
             "description": "Forbidden",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -47,7 +47,7 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -57,7 +57,7 @@
           "422": {
             "description": "Unprocessable Entity",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -67,7 +67,7 @@
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -77,7 +77,7 @@
           "501": {
             "description": "Not Implemented",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -87,7 +87,7 @@
           "553": {
             "description": "Version Not Supported",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -119,7 +119,7 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/EntryInfoResponse"
                 }
@@ -129,7 +129,7 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -139,7 +139,7 @@
           "403": {
             "description": "Forbidden",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -149,7 +149,7 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -159,7 +159,7 @@
           "422": {
             "description": "Unprocessable Entity",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -169,7 +169,7 @@
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -179,7 +179,7 @@
           "501": {
             "description": "Not Implemented",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -189,7 +189,7 @@
           "553": {
             "description": "Version Not Supported",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -301,7 +301,7 @@
             "required": false,
             "schema": {
               "title": "Page Number",
-              "minimum": 0.0,
+              "minimum": 1.0,
               "type": "integer",
               "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
               "default": 0
@@ -378,7 +378,7 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/LinksResponse"
                 }
@@ -388,7 +388,7 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -398,7 +398,7 @@
           "403": {
             "description": "Forbidden",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -408,7 +408,7 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -418,7 +418,7 @@
           "422": {
             "description": "Unprocessable Entity",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -428,7 +428,7 @@
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -438,7 +438,7 @@
           "501": {
             "description": "Not Implemented",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -448,7 +448,7 @@
           "553": {
             "description": "Version Not Supported",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -560,7 +560,7 @@
             "required": false,
             "schema": {
               "title": "Page Number",
-              "minimum": 0.0,
+              "minimum": 1.0,
               "type": "integer",
               "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
               "default": 0
@@ -637,7 +637,7 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ReferenceResponseMany"
                 }
@@ -647,7 +647,7 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -657,7 +657,7 @@
           "403": {
             "description": "Forbidden",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -667,7 +667,7 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -677,7 +677,7 @@
           "422": {
             "description": "Unprocessable Entity",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -687,7 +687,7 @@
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -697,7 +697,7 @@
           "501": {
             "description": "Not Implemented",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -707,7 +707,7 @@
           "553": {
             "description": "Version Not Supported",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -802,7 +802,7 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ReferenceResponseOne"
                 }
@@ -812,7 +812,7 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -822,7 +822,7 @@
           "403": {
             "description": "Forbidden",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -832,7 +832,7 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -842,7 +842,7 @@
           "422": {
             "description": "Unprocessable Entity",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -852,7 +852,7 @@
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -862,7 +862,7 @@
           "501": {
             "description": "Not Implemented",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -872,7 +872,7 @@
           "553": {
             "description": "Version Not Supported",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -984,7 +984,7 @@
             "required": false,
             "schema": {
               "title": "Page Number",
-              "minimum": 0.0,
+              "minimum": 1.0,
               "type": "integer",
               "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
               "default": 0
@@ -1061,7 +1061,7 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/StructureResponseMany"
                 }
@@ -1071,7 +1071,7 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1081,7 +1081,7 @@
           "403": {
             "description": "Forbidden",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1091,7 +1091,7 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1101,7 +1101,7 @@
           "422": {
             "description": "Unprocessable Entity",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1111,7 +1111,7 @@
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1121,7 +1121,7 @@
           "501": {
             "description": "Not Implemented",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1131,7 +1131,7 @@
           "553": {
             "description": "Version Not Supported",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1226,7 +1226,7 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/StructureResponseOne"
                 }
@@ -1236,7 +1236,7 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1246,7 +1246,7 @@
           "403": {
             "description": "Forbidden",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1256,7 +1256,7 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1266,7 +1266,7 @@
           "422": {
             "description": "Unprocessable Entity",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1276,7 +1276,7 @@
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1286,7 +1286,7 @@
           "501": {
             "description": "Not Implemented",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1296,7 +1296,7 @@
           "553": {
             "description": "Version Not Supported",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -1358,7 +1358,9 @@
                 "type": "integer"
               }
             },
-            "description": "Index of the sites (0-based) that belong to each group for each assembly.\n\n- **Examples**:\n    - `[[1], [2]]`: two groups, one with the second site, one with the third.\n    - `[[1,2], [3]]`: one group with the second and third site, one with the fourth."
+            "description": "Index of the sites (0-based) that belong to each group for each assembly.\n\n- **Examples**:\n    - `[[1], [2]]`: two groups, one with the second site, one with the third.\n    - `[[1,2], [3]]`: one group with the second and third site, one with the fourth.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "must"
           },
           "group_probabilities": {
             "title": "Group Probabilities",
@@ -1366,7 +1368,9 @@
             "items": {
               "type": "number"
             },
-            "description": "Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\nIt SHOULD sum to one.\nSee below for examples of how to specify the probability of the occurrence of a vacancy.\nThe possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`."
+            "description": "Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\nIt SHOULD sum to one.\nSee below for examples of how to specify the probability of the occurrence of a vacancy.\nThe possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "must"
           }
         },
         "description": "A description of groups of sites that are statistically correlated.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n      Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n      The second group is formed by the fourth site. Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n      30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent)."
@@ -1398,7 +1402,12 @@
             "title": "Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "example": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
           }
         },
         "description": "A JSON object containing information about an available API version"
@@ -1417,7 +1426,12 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "example": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
           },
           "available_api_versions": {
             "title": "Available Api Versions",
@@ -1478,12 +1492,14 @@
           "id": {
             "title": "Id",
             "pattern": "^/$",
-            "type": "string"
+            "type": "string",
+            "default": "/"
           },
           "type": {
             "title": "Type",
             "pattern": "^info$",
-            "type": "string"
+            "type": "string",
+            "default": "info"
           },
           "links": {
             "title": "Links",
@@ -1528,7 +1544,7 @@
           "description": {
             "title": "Description",
             "type": "string",
-            "description": "OPTIONAL human-readable description of the relationship"
+            "description": "OPTIONAL human-readable description of the relationship."
           }
         },
         "description": "Specific meta field for base relationship resource"
@@ -1669,7 +1685,7 @@
                 "$ref": "#/components/schemas/EntryInfoResource"
               }
             ],
-            "description": "OPTIMADE information for an entry endpoint"
+            "description": "OPTIMADE information for an entry endpoint."
           },
           "meta": {
             "title": "Meta",
@@ -1756,12 +1772,16 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "type": {
             "title": "Type",
             "type": "string",
-            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`"
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "links": {
             "title": "Links",
@@ -1812,13 +1832,17 @@
           "immutable_id": {
             "title": "Immutable Id",
             "type": "string",
-            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "optional"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
-            "format": "date-time"
+            "format": "date-time",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           }
         },
         "description": "Contains key-value pairs representing the entry's properties."
@@ -1890,9 +1914,9 @@
             "title": "About",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1935,7 +1959,7 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "description": "A meta object containing non-standard information"
+            "description": "A meta object containing non-standard information."
           },
           "errors": {
             "title": "Errors",
@@ -2011,9 +2035,9 @@
             "title": "Homepage",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2026,9 +2050,9 @@
             "title": "Source Url",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2050,9 +2074,9 @@
             "title": "Issue Tracker",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2095,7 +2119,7 @@
                 "$ref": "#/components/schemas/BaseInfoResource"
               }
             ],
-            "description": "The implementations /info data"
+            "description": "The implementations /info data."
           },
           "meta": {
             "title": "Meta",
@@ -2216,13 +2240,16 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "type": {
             "title": "Type",
             "pattern": "^links$",
             "type": "string",
-            "description": "These objects are described in detail in the section Links Endpoint"
+            "description": "These objects are described in detail in the section Links Endpoint",
+            "default": "links"
           },
           "links": {
             "title": "Links",
@@ -2288,9 +2315,9 @@
             "title": "Base Url",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2303,9 +2330,9 @@
             "title": "Homepage",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2366,7 +2393,7 @@
                 }
               }
             ],
-            "description": "List of unique OPTIMADE links resource objects"
+            "description": "List of unique OPTIMADE links resource objects."
           },
           "meta": {
             "title": "Meta",
@@ -2512,17 +2539,23 @@
           "name": {
             "title": "Name",
             "type": "string",
-            "description": "Full name of the person, REQUIRED."
+            "description": "Full name of the person, REQUIRED.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "must"
           },
           "firstname": {
             "title": "Firstname",
             "type": "string",
-            "description": "First name of the person."
+            "description": "First name of the person.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "lastname": {
             "title": "Lastname",
             "type": "string",
-            "description": "Last name of the person."
+            "description": "Last name of the person.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           }
         },
         "description": "A person, i.e., an author, editor or other."
@@ -2556,9 +2589,9 @@
             "title": "Homepage",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -2609,7 +2642,7 @@
             "description": "a meta object that contains non-standard meta-information about the relationship."
           }
         },
-        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource"
+        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."
       },
       "ReferenceResource": {
         "title": "ReferenceResource",
@@ -2623,13 +2656,18 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "type": {
             "title": "Type",
             "pattern": "^references$",
             "type": "string",
-            "description": "The name of the type of an entry.\n- **Type**: string.\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type <type> and ID <id> MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n- **Example**: `\"structures\"`"
+            "description": "The name of the type of an entry.\n- **Type**: string.\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type <type> and ID <id> MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n- **Example**: `\"structures\"`",
+            "default": "references",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "links": {
             "title": "Links",
@@ -2674,13 +2712,17 @@
           "immutable_id": {
             "title": "Immutable Id",
             "type": "string",
-            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "optional"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
-            "format": "date-time"
+            "format": "date-time",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           },
           "authors": {
             "title": "Authors",
@@ -2688,7 +2730,9 @@
             "items": {
               "$ref": "#/components/schemas/Person"
             },
-            "description": "List of person objects containing the authors of the reference."
+            "description": "List of person objects containing the authors of the reference.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "editors": {
             "title": "Editors",
@@ -2696,12 +2740,16 @@
             "items": {
               "$ref": "#/components/schemas/Person"
             },
-            "description": "List of person objects containing the editors of the reference."
+            "description": "List of person objects containing the editors of the reference.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "doi": {
             "title": "Doi",
             "type": "string",
-            "description": "The digital object identifier of the reference."
+            "description": "The digital object identifier of the reference.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "url": {
             "title": "Url",
@@ -2709,117 +2757,163 @@
             "minLength": 1,
             "type": "string",
             "description": "The URL of the reference.",
-            "format": "uri"
+            "format": "uri",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "address": {
             "title": "Address",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "annote": {
             "title": "Annote",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "booktitle": {
             "title": "Booktitle",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "chapter": {
             "title": "Chapter",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "crossref": {
             "title": "Crossref",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "edition": {
             "title": "Edition",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "howpublished": {
             "title": "Howpublished",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "institution": {
             "title": "Institution",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "journal": {
             "title": "Journal",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "key": {
             "title": "Key",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "month": {
             "title": "Month",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "note": {
             "title": "Note",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "number": {
             "title": "Number",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "organization": {
             "title": "Organization",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "pages": {
             "title": "Pages",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "publisher": {
             "title": "Publisher",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "school": {
             "title": "School",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "series": {
             "title": "Series",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "title": {
             "title": "Title",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "bib_type": {
             "title": "Bib Type",
             "type": "string",
-            "description": "Type of the reference, corresponding to the **type** property in the BiBTeX specification."
+            "description": "Type of the reference, corresponding to the **type** property in the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "volume": {
             "title": "Volume",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "year": {
             "title": "Year",
             "type": "string",
-            "description": "Meaning of property matches the BiBTeX specification."
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           }
         },
         "description": "Model that stores the attributes of a reference.\n\nMany properties match the meaning described in the\n[BibTeX specification](http://bibtexml.sourceforge.net/btxdoc.pdf)."
@@ -2849,7 +2943,7 @@
                 }
               }
             ],
-            "description": "List of unique OPTIMADE references entry resource objects"
+            "description": "List of unique OPTIMADE references entry resource objects."
           },
           "meta": {
             "title": "Meta",
@@ -2926,7 +3020,7 @@
                 "type": "object"
               }
             ],
-            "description": "A single references entry resource"
+            "description": "A single references entry resource."
           },
           "meta": {
             "title": "Meta",
@@ -2993,9 +3087,9 @@
             "title": "Self",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3008,9 +3102,9 @@
             "title": "Related",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3093,9 +3187,9 @@
             "title": "Self",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3129,7 +3223,12 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "example": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
           },
           "more_data_available": {
             "title": "More Data Available",
@@ -3140,9 +3239,9 @@
             "title": "Schema",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3235,7 +3334,9 @@
           "name": {
             "title": "Name",
             "type": "string",
-            "description": "Gives the name of the species; the **name** value MUST be unique in the `species` list."
+            "description": "Gives the name of the species; the **name** value MUST be unique in the `species` list.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "must"
           },
           "chemical_symbols": {
             "title": "Chemical Symbols",
@@ -3243,7 +3344,9 @@
             "items": {
               "type": "string"
             },
-            "description": "MUST be a list of strings of all chemical elements composing this species. Each item of the list MUST be one of the following:\n\n- a valid chemical-element name, or\n- the special value `\"X\"` to represent a non-chemical element, or\n- the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\nIf any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`."
+            "description": "MUST be a list of strings of all chemical elements composing this species. Each item of the list MUST be one of the following:\n\n- a valid chemical-element symbol, or\n- the special value `\"X\"` to represent a non-chemical element, or\n- the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\nIf any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "must"
           },
           "concentration": {
             "title": "Concentration",
@@ -3251,7 +3354,9 @@
             "items": {
               "type": "number"
             },
-            "description": "MUST be a list of floats, with same length as `chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species. The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n- Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n- Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\nNote that concentrations are uncorrelated between different site (even of the same species)."
+            "description": "MUST be a list of floats, with same length as `chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species. The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n- Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n- Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\nNote that concentrations are uncorrelated between different site (even of the same species).",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "must"
           },
           "mass": {
             "title": "Mass",
@@ -3259,12 +3364,17 @@
             "items": {
               "type": "number"
             },
-            "description": "If present MUST be a list of floats expressed in a.m.u.\nElements denoting vacancies MUST have masses equal to 0."
+            "description": "If present MUST be a list of floats expressed in a.m.u.\nElements denoting vacancies MUST have masses equal to 0.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-unit": "a.m.u.",
+            "x-optimade-support": "optional"
           },
           "original_name": {
             "title": "Original Name",
             "type": "string",
-            "description": "Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\nNote: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation."
+            "description": "Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\nNote: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "attached": {
             "title": "Attached",
@@ -3272,7 +3382,9 @@
             "items": {
               "type": "string"
             },
-            "description": "If provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element."
+            "description": "If provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "nattached": {
             "title": "Nattached",
@@ -3280,7 +3392,9 @@
             "items": {
               "type": "integer"
             },
-            "description": "If provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key."
+            "description": "If provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           }
         },
         "description": "A list describing the species of the sites of this structure.\n\nSpecies can represent pure chemical elements, virtual-crystal atoms representing a\nstatistical occupation of a given site by multiple chemical elements, and/or a\nlocation to which there are attached atoms, i.e., atoms whose precise location are\nunknown beyond that they are attached to that position (frequently used to indicate\nhydrogen atoms attached to another element, e.g., a carbon with three attached\nhydrogens might represent a methyl group, -CH3).\n\n- **Examples**:\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - `[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": [0.0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - `[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - `[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.\n    - `[ {\"name\": \"CH3\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"attached\": [\"H\"], \"nattached\": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms."
@@ -3334,7 +3448,7 @@
             "description": "a meta object that contains non-standard meta-information about the relationship."
           }
         },
-        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource"
+        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."
       },
       "StructureResource": {
         "title": "StructureResource",
@@ -3348,13 +3462,18 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "type": {
             "title": "Type",
             "pattern": "^structures$",
             "type": "string",
-            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Examples**:\n    - `\"structures\"`"
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Examples**:\n    - `\"structures\"`",
+            "default": "structures",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "links": {
             "title": "Links",
@@ -3413,14 +3532,18 @@
           "immutable_id": {
             "title": "Immutable Id",
             "type": "string",
-            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "optional"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
             "format": "date-time",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           },
           "elements": {
             "title": "Elements",
@@ -3428,14 +3551,18 @@
             "items": {
               "type": "string"
             },
-            "description": "Symbols of the different elements present in the structure.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The strings are the chemical symbols, i.e., either a single uppercase letter or an uppercase letter followed by a number of lowercase letters.\n    - The order MUST be alphabetical.\n    - MUST refer to the same elements in the same order, and therefore be of the same length, as `elements_ratios`, if the latter is provided.\n    - Note: This property SHOULD NOT contain the string \"X\" to indicate non-chemical elements or \"vacancy\" to indicate vacancies (in contrast to the field `chemical_symbols` for the `species` property).\n\n- **Examples**:\n    - `[\"Si\"]`\n    - `[\"Al\",\"O\",\"Si\"]`\n\n- **Query examples**:\n    - A filter that matches all records of structures that contain Si, Al **and** O, and possibly other elements: `elements HAS ALL \"Si\", \"Al\", \"O\"`.\n    - To match structures with exactly these three elements, use `elements HAS ALL \"Si\", \"Al\", \"O\" AND elements LENGTH 3`.\n    - Note: length queries on this property can be equivalently formulated by filtering on the `nelements`_ property directly.",
-            "nullable": true
+            "description": "The chemical symbols of the different elements present in the structure.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The strings are the chemical symbols, i.e., either a single uppercase letter or an uppercase letter followed by a number of lowercase letters.\n    - The order MUST be alphabetical.\n    - MUST refer to the same elements in the same order, and therefore be of the same length, as `elements_ratios`, if the latter is provided.\n    - Note: This property SHOULD NOT contain the string \"X\" to indicate non-chemical elements or \"vacancy\" to indicate vacancies (in contrast to the field `chemical_symbols` for the `species` property).\n\n- **Examples**:\n    - `[\"Si\"]`\n    - `[\"Al\",\"O\",\"Si\"]`\n\n- **Query examples**:\n    - A filter that matches all records of structures that contain Si, Al **and** O, and possibly other elements: `elements HAS ALL \"Si\", \"Al\", \"O\"`.\n    - To match structures with exactly these three elements, use `elements HAS ALL \"Si\", \"Al\", \"O\" AND elements LENGTH 3`.\n    - Note: length queries on this property can be equivalently formulated by filtering on the `nelements`_ property directly.",
+            "nullable": true,
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           },
           "nelements": {
             "title": "Nelements",
             "type": "integer",
             "description": "Number of different elements in the structure as an integer.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - MUST be equal to the lengths of the list properties `elements` and `elements_ratios`, if they are provided.\n\n- **Examples**:\n    - `3`\n\n- **Querying**:\n    - Note: queries on this property can equivalently be formulated using `elements LENGTH`.\n    - A filter that matches structures that have exactly 4 elements: `nelements=4`.\n    - A filter that matches structures that have between 2 and 7 elements: `nelements>=2 AND nelements<=7`.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           },
           "elements_ratios": {
             "title": "Elements Ratios",
@@ -3444,33 +3571,43 @@
               "type": "number"
             },
             "description": "Relative proportions of different elements in the structure.\n\n- **Type**: list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - Composed by the proportions of elements in the structure as a list of floating point numbers.\n    - The sum of the numbers MUST be 1.0 (within floating point accuracy)\n    - MUST refer to the same elements in the same order, and therefore be of the same length, as `elements`, if the latter is provided.\n\n- **Examples**:\n    - `[1.0]`\n    - `[0.3333333333333333, 0.2222222222222222, 0.4444444444444444]`\n\n- **Query examples**:\n    - Note: Useful filters can be formulated using the set operator syntax for correlated values.\n      However, since the values are floating point values, the use of equality comparisons is generally inadvisable.\n    - OPTIONAL: a filter that matches structures where approximately 1/3 of the atoms in the structure are the element Al is: `elements:elements_ratios HAS ALL \"Al\":>0.3333, \"Al\":<0.3334`.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           },
           "chemical_formula_descriptive": {
             "title": "Chemical Formula Descriptive",
             "type": "string",
             "description": "The chemical formula for a structure as a string in a form chosen by the API implementation.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The chemical formula is given as a string consisting of properly capitalized element symbols followed by integers or decimal numbers, balanced parentheses, square, and curly brackets `(`,`)`, `[`,`]`, `{`, `}`, commas, the `+`, `-`, `:` and `=` symbols. The parentheses are allowed to be followed by a number. Spaces are allowed anywhere except within chemical symbols. The order of elements and any groupings indicated by parentheses or brackets are chosen freely by the API implementation.\n    - The string SHOULD be arithmetically consistent with the element ratios in the `chemical_formula_reduced` property.\n    - It is RECOMMENDED, but not mandatory, that symbols, parentheses and brackets, if used, are used with the meanings prescribed by [IUPAC's Nomenclature of Organic Chemistry](https://www.qmul.ac.uk/sbcs/iupac/bibliog/blue.html).\n\n- **Examples**:\n    - `\"(H2O)2 Na\"`\n    - `\"NaCl\"`\n    - `\"CaCO3\"`\n    - `\"CCaO3\"`\n    - `\"(CH3)3N+ - [CH2]2-OH = Me3N+ - CH2 - CH2OH\"`\n\n- **Query examples**:\n    - Note: the free-form nature of this property is likely to make queries on it across different databases inconsistent.\n    - A filter that matches an exactly given formula: `chemical_formula_descriptive=\"(H2O)2 Na\"`.\n    - A filter that does a partial match: `chemical_formula_descriptive CONTAINS \"H2O\"`.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           },
           "chemical_formula_reduced": {
             "title": "Chemical Formula Reduced",
-            "pattern": "^([A-Z][a-z]?\\d*)*$",
+            "pattern": "^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
             "type": "string",
             "description": "The reduced chemical formula for a structure as a string with element symbols and integer chemical proportion numbers.\nThe proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property.\n      However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n      Intricate queries on formula components are instead suggested to be formulated using set-type filter operators on the multi valued `elements` and `elements_ratios` properties.\n    - Element symbols MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in alphabetical order, followed by their integer chemical proportion number.\n    - For structures with no partial occupation, the chemical proportion numbers are the smallest integers for which the chemical proportion is exactly correct.\n    - For structures with partial occupation, the chemical proportion numbers are integers that within reasonable approximation indicate the correct chemical proportions. The precise details of how to perform the rounding is chosen by the API implementation.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2NaO\"`\n    - `\"ClNa\"`\n    - `\"CCaO3\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_reduced=\"H2NaO\"`.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           },
           "chemical_formula_hill": {
             "title": "Chemical Formula Hill",
-            "pattern": "^([A-Z][a-z]?\\d*)*$",
+            "pattern": "^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
             "type": "string",
-            "description": "The chemical formula for a structure in [Hill form](https://dx.doi.org/10.1021/ja02046a005) with element symbols followed by integer chemical proportion numbers. The proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, only a subset of the filter features MAY be supported.\n    - The overall scale factor of the chemical proportions is chosen such that the resulting values are integers that indicate the most chemically relevant unit of which the system is composed.\n      For example, if the structure is a repeating unit cell with four hydrogens and four oxygens that represents two hydroperoxide molecules, `chemical_formula_hill` is `\"H2O2\"` (i.e., not `\"HO\"`, nor `\"H4O4\"`).\n    - If the chemical insight needed to ascribe a Hill formula to the system is not present, the property MUST be handled as unset.\n    - Element symbols MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in [Hill order](https://dx.doi.org/10.1021/ja02046a005), followed by their integer chemical proportion number.\n      Hill order means: if carbon is present, it is placed first, and if also present, hydrogen is placed second.\n      After that, all other elements are ordered alphabetically.\n      If carbon is not present, all elements are ordered alphabetically.\n    - If the system has sites with partial occupation and the total occupations of each element do not all sum up to integers, then the Hill formula SHOULD be handled as unset.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2O2\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_hill=\"H2O2\"`."
+            "description": "The chemical formula for a structure in [Hill form](https://dx.doi.org/10.1021/ja02046a005) with element symbols followed by integer chemical proportion numbers. The proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, only a subset of the filter features MAY be supported.\n    - The overall scale factor of the chemical proportions is chosen such that the resulting values are integers that indicate the most chemically relevant unit of which the system is composed.\n      For example, if the structure is a repeating unit cell with four hydrogens and four oxygens that represents two hydroperoxide molecules, `chemical_formula_hill` is `\"H2O2\"` (i.e., not `\"HO\"`, nor `\"H4O4\"`).\n    - If the chemical insight needed to ascribe a Hill formula to the system is not present, the property MUST be handled as unset.\n    - Element symbols MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in [Hill order](https://dx.doi.org/10.1021/ja02046a005), followed by their integer chemical proportion number.\n      Hill order means: if carbon is present, it is placed first, and if also present, hydrogen is placed second.\n      After that, all other elements are ordered alphabetically.\n      If carbon is not present, all elements are ordered alphabetically.\n    - If the system has sites with partial occupation and the total occupations of each element do not all sum up to integers, then the Hill formula SHOULD be handled as unset.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2O2\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_hill=\"H2O2\"`.",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "chemical_formula_anonymous": {
             "title": "Chemical Formula Anonymous",
-            "pattern": "^([A-Z][a-z]?\\d*)*$",
+            "pattern": "^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
             "type": "string",
             "description": "The anonymous formula is the `chemical_formula_reduced`, but where the elements are instead first ordered by their chemical proportion number, and then, in order left to right, replaced by anonymous symbols A, B, C, ..., Z, Aa, Ba, ..., Za, Ab, Bb, ... and so on.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property.\n      However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n\n- **Examples**:\n    - `\"A2B\"`\n    - `\"A42B42C16D12E10F9G5\"`\n\n- **Querying**:\n    - A filter that matches an exactly given formula is `chemical_formula_anonymous=\"A2B\"`.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           },
           "dimension_types": {
             "title": "Dimension Types",
@@ -3481,13 +3618,17 @@
               "$ref": "#/components/schemas/Periodicity"
             },
             "description": "List of three integers.\nFor each of the three directions indicated by the three lattice vectors (see property `lattice_vectors`), this list indicates if the direction is periodic (value `1`) or non-periodic (value `0`).\nNote: the elements in this list each refer to the direction of the corresponding entry in `lattice_vectors` and *not* the Cartesian x, y, z directions.\n\n- **Type**: list of integers.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n    - MUST be a list of length 3.\n    - Each integer element MUST assume only the value 0 or 1.\n\n- **Examples**:\n    - For a molecule: `[0, 0, 0]`\n    - For a wire along the direction specified by the third lattice vector: `[0, 0, 1]`\n    - For a 2D surface/slab, periodic on the plane defined by the first and third lattice vectors: `[1, 0, 1]`\n    - For a bulk 3D system: `[1, 1, 1]`",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "should"
           },
           "nperiodic_dimensions": {
             "title": "Nperiodic Dimensions",
             "type": "integer",
             "description": "An integer specifying the number of periodic dimensions in the structure, equivalent to the number of non-zero entries in `dimension_types`.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The integer value MUST be between 0 and 3 inclusive and MUST be equal to the sum of the items in the `dimension_types` property.\n    - This property only reflects the treatment of the lattice vectors provided for the structure, and not any physical interpretation of the dimensionality of its contents.\n\n- **Examples**:\n    - `2` should be indicated in cases where `dimension_types` is any of `[1, 1, 0]`, `[1, 0, 1]`, `[0, 1, 1]`.\n\n- **Query examples**:\n    - Match only structures with exactly 3 periodic dimensions: `nperiodic_dimensions=3`\n    - Match all structures with 2 or fewer periodic dimensions: `nperiodic_dimensions<=2`",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           },
           "lattice_vectors": {
             "title": "Lattice Vectors",
@@ -3495,35 +3636,43 @@
             "minItems": 3,
             "type": "array",
             "items": {
+              "maxItems": 3,
+              "minItems": 3,
               "type": "array",
               "items": {
                 "type": "number"
-              },
-              "minItems": 3,
-              "maxItems": 3
+              }
             },
             "description": "The three lattice vectors in Cartesian coordinates, in \u00e5ngstr\u00f6m (\u00c5).\n\n- **Type**: list of list of floats or unknown values.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST be a list of three vectors *a*, *b*, and *c*, where each of the vectors MUST BE a list of the vector's coordinates along the x, y, and z Cartesian coordinates.\n      (Therefore, the first index runs over the three lattice vectors and the second index runs over the x, y, z Cartesian coordinates).\n    - For databases that do not define an absolute Cartesian system (e.g., only defining the length and angles between vectors), the first lattice vector SHOULD be set along *x* and the second on the *xy*-plane.\n    - MUST always contain three vectors of three coordinates each, independently of the elements of property `dimension_types`.\n      The vectors SHOULD by convention be chosen so the determinant of the `lattice_vectors` matrix is different from zero.\n      The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.\n    - The coordinates of the lattice vectors of non-periodic dimensions (i.e., those dimensions for which `dimension_types` is `0`) MAY be given as a list of all `null` values.\n        If a lattice vector contains the value `null`, all coordinates of that lattice vector MUST be `null`.\n\n- **Examples**:\n    - `[[4.0,0.0,0.0],[0.0,4.0,0.0],[0.0,1.0,4.0]]` represents a cell, where the first vector is `(4, 0, 0)`, i.e., a vector aligned along the `x` axis of length 4 \u00c5; the second vector is `(0, 4, 0)`; and the third vector is `(0, 1, 4)`.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "optional",
+            "x-optimade-unit": "\u00c5",
+            "x-optimade-support": "should"
           },
           "cartesian_site_positions": {
             "title": "Cartesian Site Positions",
             "type": "array",
             "items": {
+              "maxItems": 3,
+              "minItems": 3,
               "type": "array",
               "items": {
                 "type": "number"
-              },
-              "minItems": 3,
-              "maxItems": 3
+              }
             },
             "description": "Cartesian positions of each site in the structure.\nA site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the `species_at_sites` property, and the species themselves are described in the `species` property.\n\n- **Type**: list of list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - It MUST be a list of length equal to the number of sites in the structure, where every element is a list of the three Cartesian coordinates of a site expressed as float values in the unit angstrom (\u00c5).\n    - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`).\n\n- **Examples**:\n    - `[[0,0,0],[0,0,2]]` indicates a structure with two sites, one sitting at the origin and one along the (positive) *z*-axis, 2 \u00c5 away from the origin.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "optional",
+            "x-optimade-unit": "\u00c5",
+            "x-optimade-support": "should"
           },
           "nsites": {
             "title": "Nsites",
             "type": "integer",
             "description": "An integer specifying the length of the `cartesian_site_positions` property.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `42`\n\n- **Query examples**:\n    - Match only structures with exactly 4 sites: `nsites=4`\n    - Match structures that have between 2 and 7 sites: `nsites>=2 AND nsites<=7`",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           },
           "species": {
             "title": "Species",
@@ -3532,7 +3681,9 @@
               "$ref": "#/components/schemas/Species"
             },
             "description": "A list describing the species of the sites of this structure.\nSpecies can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (frequently used to indicate hydrogen atoms attached to another element, e.g., a carbon with three attached hydrogens might represent a methyl group, -CH3).\n\n- **Type**: list of dictionary with keys:\n    - `name`: string (REQUIRED)\n    - `chemical_symbols`: list of strings (REQUIRED)\n    - `concentration`: list of float (REQUIRED)\n    - `attached`: list of strings (REQUIRED)\n    - `nattached`: list of integers (OPTIONAL)\n    - `mass`: list of floats (OPTIONAL)\n    - `original_name`: string (OPTIONAL).\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - Each list member MUST be a dictionary with the following keys:\n        - **name**: REQUIRED; gives the name of the species; the **name** value MUST be unique in the `species` list;\n        - **chemical_symbols**: REQUIRED; MUST be a list of strings of all chemical elements composing this species.\n          Each item of the list MUST be one of the following:\n            - a valid chemical-element symbol, or\n            - the special value `\"X\"` to represent a non-chemical element, or\n            - the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\n          If any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`.\n\n        - **concentration**: REQUIRED; MUST be a list of floats, with same length as `chemical_symbols`.\n          The numbers represent the relative concentration of the corresponding chemical symbol in this species.\n          The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n            - Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n            - Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\n            Note that concentrations are uncorrelated between different sites (even of the same species).\n\n        - **attached**: OPTIONAL; if provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element.\n\n        - **nattached**: OPTIONAL; if provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the `attached` key.\n\n          The implementation MUST include either both or none of the `attached` and `nattached` keys, and if they are provided, they MUST be of the same length.\n          Furthermore, if they are provided, the `structure_features` property MUST include the string `site_attachments`.\n\n        - **mass**: OPTIONAL. If present MUST be a list of floats, with the same length as `chemical_symbols`, providing element masses expressed in a.m.u.\n          Elements denoting vacancies MUST have masses equal to 0.\n\n        - **original_name**: OPTIONAL. Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\n          Note: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.\n\n          The main use of this field is for source databases that use species names, containing characters that are not allowed (see description of the list property `species_at_sites`).\n\n    - For systems that have only species formed by a single chemical symbol, and that have at most one species per chemical symbol, SHOULD use the chemical symbol as species name (e.g., `\"Ti\"` for titanium, `\"O\"` for oxygen, etc.)\n      However, note that this is OPTIONAL, and client implementations MUST NOT assume that the key corresponds to a chemical symbol, nor assume that if the species name is a valid chemical symbol, that it represents a species with that chemical symbol.\n      This means that a species `{\"name\": \"C\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]}` is valid and represents a titanium species (and *not* a carbon species).\n    - It is NOT RECOMMENDED that a structure includes species that do not have at least one corresponding site.\n\n- **Examples**:\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - `[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": [0.0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - `[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - `[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.\n    - `[ {\"name\": \"CH3\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"attached\": [\"H\"], \"nattached\": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "should"
           },
           "species_at_sites": {
             "title": "Species At Sites",
@@ -3541,7 +3692,9 @@
               "type": "string"
             },
             "description": "Name of the species at each site (where values for sites are specified with the same order of the property `cartesian_site_positions`).\nThe properties of the species are found in the property `species`.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST have length equal to the number of sites in the structure (first dimension of the list property `cartesian_site_positions`).\n    - Each species name mentioned in the `species_at_sites` list MUST be described in the list property `species` (i.e. for each value in the `species_at_sites` list there MUST exist exactly one dictionary in the `species` list with the `name` attribute equal to the corresponding `species_at_sites` value).\n    - Each site MUST be associated only to a single species.\n      **Note**: However, species can represent mixtures of atoms, and multiple species MAY be defined for the same chemical element.\n      This latter case is useful when different atoms of the same type need to be grouped or distinguished, for instance in simulation codes to assign different initial spin states.\n\n- **Examples**:\n    - `[\"Ti\",\"O2\"]` indicates that the first site is hosting a species labeled `\"Ti\"` and the second a species labeled `\"O2\"`.\n    - `[\"Ac\", \"Ac\", \"Ag\", \"Ir\"]` indicating the first two sites contains the `\"Ac\"` species, while the third and fourth sites contain the `\"Ag\"` and `\"Ir\"` species, respectively.",
-            "nullable": true
+            "nullable": true,
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "should"
           },
           "assemblies": {
             "title": "Assemblies",
@@ -3549,7 +3702,9 @@
             "items": {
               "$ref": "#/components/schemas/Assembly"
             },
-            "description": "A description of groups of sites that are statistically correlated.\n\n- **Type**: list of dictionary with keys:\n    - `sites_in_groups`: list of list of integers (REQUIRED)\n    - `group_probabilities`: list of floats (REQUIRED)\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - The property SHOULD be `null` for entries that have no partial occupancies.\n    - If present, the correct flag MUST be set in the list `structure_features`.\n    - Client implementations MUST check its presence (as its presence changes the interpretation of the structure).\n    - If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have the following two keys:\n        - **sites_in_groups**: Index of the sites (0-based) that belong to each group for each assembly.\n\n            Example: `[[1], [2]]`: two groups, one with the second site, one with the third.\n            Example: `[[1,2], [3]]`: one group with the second and third site, one with the fourth.\n\n        - **group_probabilities**: Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\n            It SHOULD sum to one.\n            See below for examples of how to specify the probability of the occurrence of a vacancy.\n            The possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.\n\n    - If a site is not present in any group, it means that it is present with 100 % probability (as if no assembly was specified).\n    - A site MUST NOT appear in more than one group.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n        Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n        The second group is formed by the fourth site.\n        Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n        30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent).\n\n- **Notes**:\n    - Assemblies are essential to represent, for instance, the situation where an atom can statistically occupy two different positions (sites).\n\n    - By defining groups, it is possible to represent, e.g., the case where a functional molecule (and not just one atom) is either present or absent (or the case where it it is present in two conformations)\n\n    - Considerations on virtual alloys and on vacancies: In the special case of a virtual alloy, these specifications allow two different, equivalent ways of specifying them.\n        For instance, for a site at the origin with 30 % probability of being occupied by Si, 50 % probability of being occupied by Ge, and 20 % of being a vacancy, the following two representations are possible:\n\n        - Using a single species:\n            ```json\n            {\n              \"cartesian_site_positions\": [[0,0,0]],\n              \"species_at_sites\": [\"SiGe-vac\"],\n              \"species\": [\n              {\n                \"name\": \"SiGe-vac\",\n                \"chemical_symbols\": [\"Si\", \"Ge\", \"vacancy\"],\n                \"concentration\": [0.3, 0.5, 0.2]\n              }\n              ]\n              // ...\n            }\n            ```\n\n        - Using multiple species and the assemblies:\n            ```json\n            {\n              \"cartesian_site_positions\": [ [0,0,0], [0,0,0], [0,0,0] ],\n              \"species_at_sites\": [\"Si\", \"Ge\", \"vac\"],\n              \"species\": [\n                { \"name\": \"Si\", \"chemical_symbols\": [\"Si\"], \"concentration\": [1.0] },\n                { \"name\": \"Ge\", \"chemical_symbols\": [\"Ge\"], \"concentration\": [1.0] },\n                { \"name\": \"vac\", \"chemical_symbols\": [\"vacancy\"], \"concentration\": [1.0] }\n              ],\n              \"assemblies\": [\n                {\n              \"sites_in_groups\": [ [0], [1], [2] ],\n              \"group_probabilities\": [0.3, 0.5, 0.2]\n                }\n              ]\n              // ...\n            }\n            ```\n\n    - It is up to the database provider to decide which representation to use, typically depending on the internal format in which the structure is stored.\n        However, given a structure identified by a unique ID, the API implementation MUST always provide the same representation for it.\n\n    - The probabilities of occurrence of different assemblies are uncorrelated.\n        So, for instance in the following case with two assemblies:\n        ```json\n        {\n          \"assemblies\": [\n            {\n              \"sites_in_groups\": [ [0], [1] ],\n              \"group_probabilities\": [0.2, 0.8],\n            },\n            {\n              \"sites_in_groups\": [ [2], [3] ],\n              \"group_probabilities\": [0.3, 0.7]\n            }\n          ]\n        }\n        ```\n\n        Site 0 is present with a probability of 20 % and site 1 with a probability of 80 %. These two sites are correlated (either site 0 or 1 is present). Similarly, site 2 is present with a probability of 30 % and site 3 with a probability of 70 %.\n        These two sites are correlated (either site 2 or 3 is present).\n        However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2*0.3 = 6 % probability; the pair (0, 3) with 0.2*0.7 = 14 % probability; the pair (1, 2) with 0.8*0.3 = 24 % probability; and the pair (1, 3) with 0.8*0.7 = 56 % probability)."
+            "description": "A description of groups of sites that are statistically correlated.\n\n- **Type**: list of dictionary with keys:\n    - `sites_in_groups`: list of list of integers (REQUIRED)\n    - `group_probabilities`: list of floats (REQUIRED)\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - The property SHOULD be `null` for entries that have no partial occupancies.\n    - If present, the correct flag MUST be set in the list `structure_features`.\n    - Client implementations MUST check its presence (as its presence changes the interpretation of the structure).\n    - If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have the following two keys:\n        - **sites_in_groups**: Index of the sites (0-based) that belong to each group for each assembly.\n\n            Example: `[[1], [2]]`: two groups, one with the second site, one with the third.\n            Example: `[[1,2], [3]]`: one group with the second and third site, one with the fourth.\n\n        - **group_probabilities**: Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\n            It SHOULD sum to one.\n            See below for examples of how to specify the probability of the occurrence of a vacancy.\n            The possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.\n\n    - If a site is not present in any group, it means that it is present with 100 % probability (as if no assembly was specified).\n    - A site MUST NOT appear in more than one group.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n        Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n        The second group is formed by the fourth site.\n        Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n        30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent).\n\n- **Notes**:\n    - Assemblies are essential to represent, for instance, the situation where an atom can statistically occupy two different positions (sites).\n\n    - By defining groups, it is possible to represent, e.g., the case where a functional molecule (and not just one atom) is either present or absent (or the case where it it is present in two conformations)\n\n    - Considerations on virtual alloys and on vacancies: In the special case of a virtual alloy, these specifications allow two different, equivalent ways of specifying them.\n        For instance, for a site at the origin with 30 % probability of being occupied by Si, 50 % probability of being occupied by Ge, and 20 % of being a vacancy, the following two representations are possible:\n\n        - Using a single species:\n            ```json\n            {\n              \"cartesian_site_positions\": [[0,0,0]],\n              \"species_at_sites\": [\"SiGe-vac\"],\n              \"species\": [\n              {\n                \"name\": \"SiGe-vac\",\n                \"chemical_symbols\": [\"Si\", \"Ge\", \"vacancy\"],\n                \"concentration\": [0.3, 0.5, 0.2]\n              }\n              ]\n              // ...\n            }\n            ```\n\n        - Using multiple species and the assemblies:\n            ```json\n            {\n              \"cartesian_site_positions\": [ [0,0,0], [0,0,0], [0,0,0] ],\n              \"species_at_sites\": [\"Si\", \"Ge\", \"vac\"],\n              \"species\": [\n                { \"name\": \"Si\", \"chemical_symbols\": [\"Si\"], \"concentration\": [1.0] },\n                { \"name\": \"Ge\", \"chemical_symbols\": [\"Ge\"], \"concentration\": [1.0] },\n                { \"name\": \"vac\", \"chemical_symbols\": [\"vacancy\"], \"concentration\": [1.0] }\n              ],\n              \"assemblies\": [\n                {\n              \"sites_in_groups\": [ [0], [1], [2] ],\n              \"group_probabilities\": [0.3, 0.5, 0.2]\n                }\n              ]\n              // ...\n            }\n            ```\n\n    - It is up to the database provider to decide which representation to use, typically depending on the internal format in which the structure is stored.\n        However, given a structure identified by a unique ID, the API implementation MUST always provide the same representation for it.\n\n    - The probabilities of occurrence of different assemblies are uncorrelated.\n        So, for instance in the following case with two assemblies:\n        ```json\n        {\n          \"assemblies\": [\n            {\n              \"sites_in_groups\": [ [0], [1] ],\n              \"group_probabilities\": [0.2, 0.8],\n            },\n            {\n              \"sites_in_groups\": [ [2], [3] ],\n              \"group_probabilities\": [0.3, 0.7]\n            }\n          ]\n        }\n        ```\n\n        Site 0 is present with a probability of 20 % and site 1 with a probability of 80 %. These two sites are correlated (either site 0 or 1 is present). Similarly, site 2 is present with a probability of 30 % and site 3 with a probability of 70 %.\n        These two sites are correlated (either site 2 or 3 is present).\n        However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2*0.3 = 6 % probability; the pair (0, 3) with 0.2*0.7 = 14 % probability; the pair (1, 2) with 0.8*0.3 = 24 % probability; and the pair (1, 3) with 0.8*0.7 = 56 % probability).",
+            "x-optimade-queryable": "optional",
+            "x-optimade-support": "optional"
           },
           "structure_features": {
             "title": "Structure Features",
@@ -3557,7 +3712,9 @@
             "items": {
               "$ref": "#/components/schemas/StructureFeatures"
             },
-            "description": "A list of strings that flag which special features are used by the structure.\n\n- **Type**: list of strings\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property.\n    Filters on the list MUST support all mandatory HAS-type queries.\n    Filter operators for comparisons on the string components MUST support equality, support for other comparison operators are OPTIONAL.\n    - MUST be an empty list if no special features are used.\n    - MUST be sorted alphabetically.\n    - If a special feature listed below is used, the list MUST contain the corresponding string.\n    - If a special feature listed below is not used, the list MUST NOT contain the corresponding string.\n    - **List of strings used to indicate special structure features**:\n        - `disorder`: this flag MUST be present if any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element.\n        - `implicit_atoms`: this flag MUST be present if the structure contains atoms that are not assigned to sites via the property `species_at_sites` (e.g., because their positions are unknown).\n           When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`, `species` and `assemblies` properties.\n        - `site_attachments`: this flag MUST be present if any one entry in the `species` list includes `attached` and `nattached`.\n        - `assemblies`: this flag MUST be present if the property `assemblies` is present.\n\n- **Examples**: A structure having implicit atoms and using assemblies: `[\"assemblies\", \"implicit_atoms\"]`"
+            "description": "A list of strings that flag which special features are used by the structure.\n\n- **Type**: list of strings\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property.\n    Filters on the list MUST support all mandatory HAS-type queries.\n    Filter operators for comparisons on the string components MUST support equality, support for other comparison operators are OPTIONAL.\n    - MUST be an empty list if no special features are used.\n    - MUST be sorted alphabetically.\n    - If a special feature listed below is used, the list MUST contain the corresponding string.\n    - If a special feature listed below is not used, the list MUST NOT contain the corresponding string.\n    - **List of strings used to indicate special structure features**:\n        - `disorder`: this flag MUST be present if any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element.\n        - `implicit_atoms`: this flag MUST be present if the structure contains atoms that are not assigned to sites via the property `species_at_sites` (e.g., because their positions are unknown).\n           When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`, `species` and `assemblies` properties.\n        - `site_attachments`: this flag MUST be present if any one entry in the `species` list includes `attached` and `nattached`.\n        - `assemblies`: this flag MUST be present if the property `assemblies` is present.\n\n- **Examples**: A structure having implicit atoms and using assemblies: `[\"assemblies\", \"implicit_atoms\"]`",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           }
         },
         "description": "This class contains the Field for the attributes used to represent a structure, e.g. unit cell, atoms, positions."
@@ -3587,7 +3744,7 @@
                 }
               }
             ],
-            "description": "List of unique OPTIMADE structures entry resource objects"
+            "description": "List of unique OPTIMADE structures entry resource objects."
           },
           "meta": {
             "title": "Meta",
@@ -3664,7 +3821,7 @@
                 "type": "object"
               }
             ],
-            "description": "A single structures entry resource"
+            "description": "A single structures entry resource."
           },
           "meta": {
             "title": "Meta",
@@ -3731,9 +3888,9 @@
             "title": "Self",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3746,9 +3903,9 @@
             "title": "Related",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3761,9 +3918,9 @@
             "title": "First",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3776,9 +3933,9 @@
             "title": "Last",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3791,9 +3948,9 @@
             "title": "Prev",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3806,9 +3963,9 @@
             "title": "Next",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -3879,7 +4036,8 @@
             "title": "Type",
             "pattern": "^warning$",
             "type": "string",
-            "description": "Warnings must be of type \"warning\""
+            "description": "Warnings must be of type \"warning\"",
+            "default": "warning"
           }
         },
         "description": "OPTIMADE-specific warning class based on OPTIMADE-specific JSON API Error.\n\nFrom the specification:\n\nA warning resource object is defined similarly to a JSON API error object, but MUST also include the field type, which MUST have the value \"warning\".\nThe field detail MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\n\nNote: Must be named \"Warnings\", since \"Warning\" is a built-in Python class."

--- a/openapi/v1.1.0/optimade_index.json
+++ b/openapi/v1.1.0/optimade_index.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTIMADE API - Index meta-database",
-    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.16.0) v0.16.0.",
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.19.1) v0.19.1.",
     "version": "1.1.0"
   },
   "paths": {
@@ -17,7 +17,7 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/IndexInfoResponse"
                 }
@@ -27,7 +27,7 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -37,7 +37,7 @@
           "403": {
             "description": "Forbidden",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -47,7 +47,7 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -57,7 +57,7 @@
           "422": {
             "description": "Unprocessable Entity",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -67,7 +67,7 @@
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -77,7 +77,7 @@
           "501": {
             "description": "Not Implemented",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -87,7 +87,7 @@
           "553": {
             "description": "Version Not Supported",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -199,7 +199,7 @@
             "required": false,
             "schema": {
               "title": "Page Number",
-              "minimum": 0.0,
+              "minimum": 1.0,
               "type": "integer",
               "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
               "default": 0
@@ -276,7 +276,7 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/LinksResponse"
                 }
@@ -286,7 +286,7 @@
           "400": {
             "description": "Bad Request",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -296,7 +296,7 @@
           "403": {
             "description": "Forbidden",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -306,7 +306,7 @@
           "404": {
             "description": "Not Found",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -316,7 +316,7 @@
           "422": {
             "description": "Unprocessable Entity",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -326,7 +326,7 @@
           "500": {
             "description": "Internal Server Error",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -336,7 +336,7 @@
           "501": {
             "description": "Not Implemented",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -346,7 +346,7 @@
           "553": {
             "description": "Version Not Supported",
             "content": {
-              "application/json": {
+              "application/vnd.api+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
@@ -418,7 +418,12 @@
             "title": "Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "example": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
           }
         },
         "description": "A JSON object containing information about an available API version"
@@ -433,7 +438,7 @@
           "description": {
             "title": "Description",
             "type": "string",
-            "description": "OPTIONAL human-readable description of the relationship"
+            "description": "OPTIONAL human-readable description of the relationship."
           }
         },
         "description": "Specific meta field for base relationship resource"
@@ -505,12 +510,16 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "type": {
             "title": "Type",
             "type": "string",
-            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`"
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "links": {
             "title": "Links",
@@ -561,13 +570,17 @@
           "immutable_id": {
             "title": "Immutable Id",
             "type": "string",
-            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)"
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "optional"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
-            "format": "date-time"
+            "format": "date-time",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "should"
           }
         },
         "description": "Contains key-value pairs representing the entry's properties."
@@ -639,9 +652,9 @@
             "title": "About",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -684,7 +697,7 @@
                 "$ref": "#/components/schemas/ResponseMeta"
               }
             ],
-            "description": "A meta object containing non-standard information"
+            "description": "A meta object containing non-standard information."
           },
           "errors": {
             "title": "Errors",
@@ -760,9 +773,9 @@
             "title": "Homepage",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -775,9 +788,9 @@
             "title": "Source Url",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -799,9 +812,9 @@
             "title": "Issue Tracker",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -843,7 +856,12 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "example": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
           },
           "available_api_versions": {
             "title": "Available Api Versions",
@@ -886,7 +904,8 @@
           "is_index": {
             "title": "Is Index",
             "type": "boolean",
-            "description": "This must be `true` since this is an index meta-database (see section Index Meta-Database)."
+            "description": "This must be `true` since this is an index meta-database (see section Index Meta-Database).",
+            "default": true
           }
         },
         "description": "Attributes for Base URL Info endpoint for an Index Meta-Database"
@@ -904,12 +923,14 @@
           "id": {
             "title": "Id",
             "pattern": "^/$",
-            "type": "string"
+            "type": "string",
+            "default": "/"
           },
           "type": {
             "title": "Type",
             "pattern": "^info$",
-            "type": "string"
+            "type": "string",
+            "default": "info"
           },
           "links": {
             "title": "Links",
@@ -958,7 +979,7 @@
                 "$ref": "#/components/schemas/IndexInfoResource"
               }
             ],
-            "description": "Index meta-database /info data"
+            "description": "Index meta-database /info data."
           },
           "meta": {
             "title": "Meta",
@@ -1098,13 +1119,16 @@
           "id": {
             "title": "Id",
             "type": "string",
-            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`"
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-queryable": "must",
+            "x-optimade-support": "must"
           },
           "type": {
             "title": "Type",
             "pattern": "^links$",
             "type": "string",
-            "description": "These objects are described in detail in the section Links Endpoint"
+            "description": "These objects are described in detail in the section Links Endpoint",
+            "default": "links"
           },
           "links": {
             "title": "Links",
@@ -1170,9 +1194,9 @@
             "title": "Base Url",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1185,9 +1209,9 @@
             "title": "Homepage",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1248,7 +1272,7 @@
                 }
               }
             ],
-            "description": "List of unique OPTIMADE links resource objects"
+            "description": "List of unique OPTIMADE links resource objects."
           },
           "meta": {
             "title": "Meta",
@@ -1404,9 +1428,9 @@
             "title": "Homepage",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1457,7 +1481,7 @@
             "description": "a meta object that contains non-standard meta-information about the relationship."
           }
         },
-        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource"
+        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."
       },
       "RelatedLinksResource": {
         "title": "RelatedLinksResource",
@@ -1475,7 +1499,8 @@
           "type": {
             "title": "Type",
             "pattern": "^links$",
-            "type": "string"
+            "type": "string",
+            "default": "links"
           }
         },
         "description": "A related Links resource object"
@@ -1488,9 +1513,9 @@
             "title": "Self",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1503,9 +1528,9 @@
             "title": "Related",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1588,9 +1613,9 @@
             "title": "Self",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1624,7 +1649,12 @@
             "title": "Api Version",
             "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
             "type": "string",
-            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`."
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "example": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
           },
           "more_data_available": {
             "title": "More Data Available",
@@ -1635,9 +1665,9 @@
             "title": "Schema",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1757,7 +1787,7 @@
             "description": "a meta object that contains non-standard meta-information about the relationship."
           }
         },
-        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource"
+        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."
       },
       "ToplevelLinks": {
         "title": "ToplevelLinks",
@@ -1767,9 +1797,9 @@
             "title": "Self",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1782,9 +1812,9 @@
             "title": "Related",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1797,9 +1827,9 @@
             "title": "First",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1812,9 +1842,9 @@
             "title": "Last",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1827,9 +1857,9 @@
             "title": "Prev",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1842,9 +1872,9 @@
             "title": "Next",
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1,
                 "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
                 "format": "uri"
               },
               {
@@ -1915,7 +1945,8 @@
             "title": "Type",
             "pattern": "^warning$",
             "type": "string",
-            "description": "Warnings must be of type \"warning\""
+            "description": "Warnings must be of type \"warning\"",
+            "default": "warning"
           }
         },
         "description": "OPTIMADE-specific warning class based on OPTIMADE-specific JSON API Error.\n\nFrom the specification:\n\nA warning resource object is defined similarly to a JSON API error object, but MUST also include the field type, which MUST have the value \"warning\".\nThe field detail MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\n\nNote: Must be named \"Warnings\", since \"Warning\" is a built-in Python class."

--- a/openapi/v1.1.0/optimade_index.json
+++ b/openapi/v1.1.0/optimade_index.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTIMADE API - Index meta-database",
-    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.19.1) v0.19.1.",
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.19.5) v0.19.5.",
     "version": "1.1.0"
   },
   "paths": {
@@ -199,10 +199,8 @@
             "required": false,
             "schema": {
               "title": "Page Number",
-              "minimum": 1.0,
               "type": "integer",
-              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
-              "default": 0
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
             },
             "name": "page_number",
             "in": "query"
@@ -511,15 +509,15 @@
             "title": "Id",
             "type": "string",
             "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "type": {
             "title": "Type",
             "type": "string",
             "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "links": {
             "title": "Links",
@@ -571,16 +569,16 @@
             "title": "Immutable Id",
             "type": "string",
             "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "optional"
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
           },
           "last_modified": {
             "title": "Last Modified",
             "type": "string",
             "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
             "format": "date-time",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "should"
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
           }
         },
         "description": "Contains key-value pairs representing the entry's properties."
@@ -1120,8 +1118,8 @@
             "title": "Id",
             "type": "string",
             "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
-            "x-optimade-queryable": "must",
-            "x-optimade-support": "must"
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
           },
           "type": {
             "title": "Type",

--- a/openapi/v1.2.0/optimade.json
+++ b/openapi/v1.2.0/optimade.json
@@ -1,0 +1,4041 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "OPTIMADE API",
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.19.5) v0.19.5.",
+    "version": "1.1.0"
+  },
+  "paths": {
+    "/info": {
+      "get": {
+        "tags": [
+          "Info"
+        ],
+        "summary": "Get Info",
+        "operationId": "get_info_info_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/info/{entry}": {
+      "get": {
+        "tags": [
+          "Info"
+        ],
+        "summary": "Get Entry Info",
+        "operationId": "get_entry_info_info__entry__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Entry",
+              "type": "string"
+            },
+            "name": "entry",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryInfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/links": {
+      "get": {
+        "tags": [
+          "Links"
+        ],
+        "summary": "Get Links",
+        "operationId": "get_links_links_get",
+        "parameters": [
+          {
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+            "required": false,
+            "schema": {
+              "title": "Filter",
+              "type": "string",
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+              "default": ""
+            },
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "required": false,
+            "schema": {
+              "title": "Response Format",
+              "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+              "default": "json"
+            },
+            "name": "response_format",
+            "in": "query"
+          },
+          {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "required": false,
+            "schema": {
+              "title": "Email Address",
+              "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+              "format": "email",
+              "default": ""
+            },
+            "name": "email_address",
+            "in": "query"
+          },
+          {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+            "required": false,
+            "schema": {
+              "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+              "default": ""
+            },
+            "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+            "required": false,
+            "schema": {
+              "title": "Sort",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+              "default": ""
+            },
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+            "required": false,
+            "schema": {
+              "title": "Page Limit",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+              "default": 20
+            },
+            "name": "page_limit",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+            "required": false,
+            "schema": {
+              "title": "Page Offset",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+              "default": 0
+            },
+            "name": "page_offset",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+            "required": false,
+            "schema": {
+              "title": "Page Number",
+              "type": "integer",
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+            },
+            "name": "page_number",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+            "required": false,
+            "schema": {
+              "title": "Page Cursor",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+              "default": 0
+            },
+            "name": "page_cursor",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+            "required": false,
+            "schema": {
+              "title": "Page Above",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+              "default": 0
+            },
+            "name": "page_above",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+            "required": false,
+            "schema": {
+              "title": "Page Below",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+              "default": 0
+            },
+            "name": "page_below",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
+            "in": "query"
+          },
+          {
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "required": false,
+            "schema": {
+              "title": "Api Hint",
+              "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
+              "type": "string",
+              "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+              "default": ""
+            },
+            "name": "api_hint",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LinksResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/references": {
+      "get": {
+        "tags": [
+          "References"
+        ],
+        "summary": "Get References",
+        "operationId": "get_references_references_get",
+        "parameters": [
+          {
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+            "required": false,
+            "schema": {
+              "title": "Filter",
+              "type": "string",
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+              "default": ""
+            },
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "required": false,
+            "schema": {
+              "title": "Response Format",
+              "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+              "default": "json"
+            },
+            "name": "response_format",
+            "in": "query"
+          },
+          {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "required": false,
+            "schema": {
+              "title": "Email Address",
+              "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+              "format": "email",
+              "default": ""
+            },
+            "name": "email_address",
+            "in": "query"
+          },
+          {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+            "required": false,
+            "schema": {
+              "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+              "default": ""
+            },
+            "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+            "required": false,
+            "schema": {
+              "title": "Sort",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+              "default": ""
+            },
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+            "required": false,
+            "schema": {
+              "title": "Page Limit",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+              "default": 20
+            },
+            "name": "page_limit",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+            "required": false,
+            "schema": {
+              "title": "Page Offset",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+              "default": 0
+            },
+            "name": "page_offset",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+            "required": false,
+            "schema": {
+              "title": "Page Number",
+              "type": "integer",
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+            },
+            "name": "page_number",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+            "required": false,
+            "schema": {
+              "title": "Page Cursor",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+              "default": 0
+            },
+            "name": "page_cursor",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+            "required": false,
+            "schema": {
+              "title": "Page Above",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+              "default": 0
+            },
+            "name": "page_above",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+            "required": false,
+            "schema": {
+              "title": "Page Below",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+              "default": 0
+            },
+            "name": "page_below",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
+            "in": "query"
+          },
+          {
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "required": false,
+            "schema": {
+              "title": "Api Hint",
+              "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
+              "type": "string",
+              "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+              "default": ""
+            },
+            "name": "api_hint",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferenceResponseMany"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/references/{entry_id}": {
+      "get": {
+        "tags": [
+          "References"
+        ],
+        "summary": "Get Single Reference",
+        "operationId": "get_single_reference_references__entry_id__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Entry Id",
+              "type": "string"
+            },
+            "name": "entry_id",
+            "in": "path"
+          },
+          {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "required": false,
+            "schema": {
+              "title": "Response Format",
+              "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+              "default": "json"
+            },
+            "name": "response_format",
+            "in": "query"
+          },
+          {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "required": false,
+            "schema": {
+              "title": "Email Address",
+              "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+              "format": "email",
+              "default": ""
+            },
+            "name": "email_address",
+            "in": "query"
+          },
+          {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+            "required": false,
+            "schema": {
+              "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+              "default": ""
+            },
+            "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
+            "in": "query"
+          },
+          {
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "required": false,
+            "schema": {
+              "title": "Api Hint",
+              "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
+              "type": "string",
+              "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+              "default": ""
+            },
+            "name": "api_hint",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferenceResponseOne"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/structures": {
+      "get": {
+        "tags": [
+          "Structures"
+        ],
+        "summary": "Get Structures",
+        "operationId": "get_structures_structures_get",
+        "parameters": [
+          {
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+            "required": false,
+            "schema": {
+              "title": "Filter",
+              "type": "string",
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+              "default": ""
+            },
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "required": false,
+            "schema": {
+              "title": "Response Format",
+              "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+              "default": "json"
+            },
+            "name": "response_format",
+            "in": "query"
+          },
+          {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "required": false,
+            "schema": {
+              "title": "Email Address",
+              "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+              "format": "email",
+              "default": ""
+            },
+            "name": "email_address",
+            "in": "query"
+          },
+          {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+            "required": false,
+            "schema": {
+              "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+              "default": ""
+            },
+            "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+            "required": false,
+            "schema": {
+              "title": "Sort",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+              "default": ""
+            },
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+            "required": false,
+            "schema": {
+              "title": "Page Limit",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+              "default": 20
+            },
+            "name": "page_limit",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+            "required": false,
+            "schema": {
+              "title": "Page Offset",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+              "default": 0
+            },
+            "name": "page_offset",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+            "required": false,
+            "schema": {
+              "title": "Page Number",
+              "type": "integer",
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+            },
+            "name": "page_number",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+            "required": false,
+            "schema": {
+              "title": "Page Cursor",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+              "default": 0
+            },
+            "name": "page_cursor",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+            "required": false,
+            "schema": {
+              "title": "Page Above",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+              "default": 0
+            },
+            "name": "page_above",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+            "required": false,
+            "schema": {
+              "title": "Page Below",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+              "default": 0
+            },
+            "name": "page_below",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
+            "in": "query"
+          },
+          {
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "required": false,
+            "schema": {
+              "title": "Api Hint",
+              "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
+              "type": "string",
+              "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+              "default": ""
+            },
+            "name": "api_hint",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StructureResponseMany"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/structures/{entry_id}": {
+      "get": {
+        "tags": [
+          "Structures"
+        ],
+        "summary": "Get Single Structure",
+        "operationId": "get_single_structure_structures__entry_id__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Entry Id",
+              "type": "string"
+            },
+            "name": "entry_id",
+            "in": "path"
+          },
+          {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "required": false,
+            "schema": {
+              "title": "Response Format",
+              "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+              "default": "json"
+            },
+            "name": "response_format",
+            "in": "query"
+          },
+          {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "required": false,
+            "schema": {
+              "title": "Email Address",
+              "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+              "format": "email",
+              "default": ""
+            },
+            "name": "email_address",
+            "in": "query"
+          },
+          {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+            "required": false,
+            "schema": {
+              "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+              "default": ""
+            },
+            "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
+            "in": "query"
+          },
+          {
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "required": false,
+            "schema": {
+              "title": "Api Hint",
+              "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
+              "type": "string",
+              "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+              "default": ""
+            },
+            "name": "api_hint",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StructureResponseOne"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/versions": {
+      "get": {
+        "tags": [
+          "Versions"
+        ],
+        "summary": "Get Versions",
+        "description": "Respond with the text/csv representation for the served versions.",
+        "operationId": "get_versions_versions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/csv; header=present": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Aggregate": {
+        "title": "Aggregate",
+        "enum": [
+          "ok",
+          "test",
+          "staging",
+          "no"
+        ],
+        "description": "Enumeration of aggregate values"
+      },
+      "Assembly": {
+        "title": "Assembly",
+        "required": [
+          "sites_in_groups",
+          "group_probabilities"
+        ],
+        "type": "object",
+        "properties": {
+          "sites_in_groups": {
+            "title": "Sites In Groups",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "description": "Index of the sites (0-based) that belong to each group for each assembly.\n\n- **Examples**:\n    - `[[1], [2]]`: two groups, one with the second site, one with the third.\n    - `[[1,2], [3]]`: one group with the second and third site, one with the fourth.",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
+          },
+          "group_probabilities": {
+            "title": "Group Probabilities",
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\nIt SHOULD sum to one.\nSee below for examples of how to specify the probability of the occurrence of a vacancy.\nThe possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
+          }
+        },
+        "description": "A description of groups of sites that are statistically correlated.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n      Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n      The second group is formed by the fourth site. Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n      30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent)."
+      },
+      "Attributes": {
+        "title": "Attributes",
+        "type": "object",
+        "properties": {},
+        "description": "Members of the attributes object (\"attributes\") represent information about the resource object in which it's defined.\nThe keys for Attributes MUST NOT be:\n    relationships\n    links\n    id\n    type"
+      },
+      "AvailableApiVersion": {
+        "title": "AvailableApiVersion",
+        "required": [
+          "url",
+          "version"
+        ],
+        "type": "object",
+        "properties": {
+          "url": {
+            "title": "Url",
+            "maxLength": 65536,
+            "minLength": 1,
+            "pattern": ".+/v[0-1](\\.[0-9]+)*/?$",
+            "type": "string",
+            "description": "A string specifying a versioned base URL that MUST adhere to the rules in section Base URL",
+            "format": "uri"
+          },
+          "version": {
+            "title": "Version",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+            "type": "string",
+            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "example": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
+          }
+        },
+        "description": "A JSON object containing information about an available API version"
+      },
+      "BaseInfoAttributes": {
+        "title": "BaseInfoAttributes",
+        "required": [
+          "api_version",
+          "available_api_versions",
+          "available_endpoints",
+          "entry_types_by_format"
+        ],
+        "type": "object",
+        "properties": {
+          "api_version": {
+            "title": "Api Version",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+            "type": "string",
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "example": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
+          },
+          "available_api_versions": {
+            "title": "Available Api Versions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvailableApiVersion"
+            },
+            "description": "A list of dictionaries of available API versions at other base URLs"
+          },
+          "formats": {
+            "title": "Formats",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of available output formats.",
+            "default": [
+              "json"
+            ]
+          },
+          "available_endpoints": {
+            "title": "Available Endpoints",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of available endpoints (i.e., the string to be appended to the versioned base URL)."
+          },
+          "entry_types_by_format": {
+            "title": "Entry Types By Format",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "Available entry endpoints as a function of output formats."
+          },
+          "is_index": {
+            "title": "Is Index",
+            "type": "boolean",
+            "description": "If true, this is an index meta-database base URL (see section Index Meta-Database). If this member is not provided, the client MUST assume this is not an index meta-database base URL (i.e., the default is for `is_index` to be `false`).",
+            "default": false
+          }
+        },
+        "description": "Attributes for Base URL Info endpoint"
+      },
+      "BaseInfoResource": {
+        "title": "BaseInfoResource",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "pattern": "^/$",
+            "type": "string",
+            "default": "/"
+          },
+          "type": {
+            "title": "Type",
+            "pattern": "^info$",
+            "type": "string",
+            "default": "info"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/BaseInfoAttributes"
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Relationships"
+              }
+            ],
+            "description": "[Relationships object](https://jsonapi.org/format/1.0/#document-resource-object-relationships)\ndescribing relationships between the resource and other JSON API resources."
+          }
+        },
+        "description": "Resource objects appear in a JSON API document to represent resources."
+      },
+      "BaseRelationshipMeta": {
+        "title": "BaseRelationshipMeta",
+        "required": [
+          "description"
+        ],
+        "type": "object",
+        "properties": {
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "OPTIONAL human-readable description of the relationship."
+          }
+        },
+        "description": "Specific meta field for base relationship resource"
+      },
+      "BaseRelationshipResource": {
+        "title": "BaseRelationshipResource",
+        "required": [
+          "id",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "Resource ID"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "Resource type"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseRelationshipMeta"
+              }
+            ],
+            "description": "Relationship meta field. MUST contain 'description' if supplied."
+          }
+        },
+        "description": "Minimum requirements to represent a relationship resource"
+      },
+      "DataType": {
+        "title": "DataType",
+        "enum": [
+          "string",
+          "integer",
+          "float",
+          "boolean",
+          "timestamp",
+          "list",
+          "dictionary",
+          "unknown"
+        ],
+        "description": "Optimade Data Types\n\n    See the section \"Data types\" in the OPTIMADE API specification for more information.\n    "
+      },
+      "EntryInfoProperty": {
+        "title": "EntryInfoProperty",
+        "required": [
+          "description"
+        ],
+        "type": "object",
+        "properties": {
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "A human-readable description of the entry property"
+          },
+          "unit": {
+            "title": "Unit",
+            "type": "string",
+            "description": "The physical unit of the entry property.\nThis MUST be a valid representation of units according to version 2.1 of [The Unified Code for Units of Measure](https://unitsofmeasure.org/ucum.html).\nIt is RECOMMENDED that non-standard (non-SI) units are described in the description for the property."
+          },
+          "sortable": {
+            "title": "Sortable",
+            "type": "boolean",
+            "description": "Defines whether the entry property can be used for sorting with the \"sort\" parameter.\nIf the entry listing endpoint supports sorting, this key MUST be present for sortable properties with value `true`."
+          },
+          "type": {
+            "title": "Type",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DataType"
+              }
+            ],
+            "description": "The type of the property's value.\nThis MUST be any of the types defined in the Data types section.\nFor the purpose of compatibility with future versions of this specification, a client MUST accept values that are not `string` values specifying any of the OPTIMADE Data types, but MUST then also disregard the `type` field.\nNote, if the value is a nested type, only the outermost type should be reported.\nE.g., for the entry resource `structures`, the `species` property is defined as a list of dictionaries, hence its `type` value would be `list`."
+          }
+        }
+      },
+      "EntryInfoResource": {
+        "title": "EntryInfoResource",
+        "required": [
+          "formats",
+          "description",
+          "properties",
+          "output_fields_by_format"
+        ],
+        "type": "object",
+        "properties": {
+          "formats": {
+            "title": "Formats",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of output formats available for this type of entry."
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "Description of the entry."
+          },
+          "properties": {
+            "title": "Properties",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/EntryInfoProperty"
+            },
+            "description": "A dictionary describing queryable properties for this entry type, where each key is a property name."
+          },
+          "output_fields_by_format": {
+            "title": "Output Fields By Format",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "Dictionary of available output fields for this entry type, where the keys are the values of the `formats` list and the values are the keys of the `properties` dictionary."
+          }
+        }
+      },
+      "EntryInfoResponse": {
+        "title": "EntryInfoResponse",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryInfoResource"
+              }
+            ],
+            "description": "OPTIMADE information for an entry endpoint."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "description": "A list of unique errors"
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            },
+            "description": "A list of unique included resources"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
+      "EntryRelationships": {
+        "title": "EntryRelationships",
+        "type": "object",
+        "properties": {
+          "references": {
+            "title": "References",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceRelationship"
+              }
+            ],
+            "description": "Object containing links to relationships with entries of the `references` type."
+          },
+          "structures": {
+            "title": "Structures",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StructureRelationship"
+              }
+            ],
+            "description": "Object containing links to relationships with entries of the `structures` type."
+          }
+        },
+        "description": "This model wraps the JSON API Relationships to include type-specific top level keys."
+      },
+      "EntryResource": {
+        "title": "EntryResource",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "title": "Attributes",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryResourceAttributes"
+              }
+            ],
+            "description": "A dictionary, containing key-value pairs representing the entry's properties, except for `type` and `id`.\nDatabase-provider-specific properties need to include the database-provider-specific prefix (see section on Database-Provider-Specific Namespace Prefixes)."
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryRelationships"
+              }
+            ],
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
+          }
+        },
+        "description": "The base model for an entry resource."
+      },
+      "EntryResourceAttributes": {
+        "title": "EntryResourceAttributes",
+        "required": [
+          "last_modified"
+        ],
+        "type": "object",
+        "properties": {
+          "immutable_id": {
+            "title": "Immutable Id",
+            "type": "string",
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
+          },
+          "last_modified": {
+            "title": "Last Modified",
+            "type": "string",
+            "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
+            "format": "date-time",
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          }
+        },
+        "description": "Contains key-value pairs representing the entry's properties."
+      },
+      "Error": {
+        "title": "Error",
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string",
+            "description": "the HTTP status code applicable to this problem, expressed as a string value."
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          }
+        },
+        "description": "An error response"
+      },
+      "ErrorLinks": {
+        "title": "ErrorLinks",
+        "type": "object",
+        "properties": {
+          "about": {
+            "title": "About",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A link that leads to further details about this particular occurrence of the problem."
+          }
+        },
+        "description": "A Links object specific to Error objects"
+      },
+      "ErrorResponse": {
+        "title": "ErrorResponse",
+        "required": [
+          "meta",
+          "errors"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Resource"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Resource"
+                }
+              }
+            ],
+            "description": "Outputted Data"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information."
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptimadeError"
+            },
+            "description": "A list of OPTIMADE-specific JSON API error objects, where the field detail MUST be present."
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            },
+            "description": "A list of unique included resources"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors MUST be present and data MUST be skipped"
+      },
+      "ErrorSource": {
+        "title": "ErrorSource",
+        "type": "object",
+        "properties": {
+          "pointer": {
+            "title": "Pointer",
+            "type": "string",
+            "description": "a JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \"/data\" for a primary data object, or \"/data/attributes/title\" for a specific attribute]."
+          },
+          "parameter": {
+            "title": "Parameter",
+            "type": "string",
+            "description": "a string indicating which URI query parameter caused the error."
+          }
+        },
+        "description": "an object containing references to the source of the error"
+      },
+      "Implementation": {
+        "title": "Implementation",
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "name of the implementation"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string",
+            "description": "version string of the current implementation"
+          },
+          "homepage": {
+            "title": "Homepage",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the homepage of the implementation."
+          },
+          "source_url": {
+            "title": "Source Url",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation source, either downloadable archive or version control system."
+          },
+          "maintainer": {
+            "title": "Maintainer",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImplementationMaintainer"
+              }
+            ],
+            "description": "A dictionary providing details about the maintainer of the implementation."
+          },
+          "issue_tracker": {
+            "title": "Issue Tracker",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation's issue tracker."
+          }
+        },
+        "description": "Information on the server implementation"
+      },
+      "ImplementationMaintainer": {
+        "title": "ImplementationMaintainer",
+        "required": [
+          "email"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "title": "Email",
+            "type": "string",
+            "description": "the maintainer's email address",
+            "format": "email"
+          }
+        },
+        "description": "Details about the maintainer of the implementation"
+      },
+      "InfoResponse": {
+        "title": "InfoResponse",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseInfoResource"
+              }
+            ],
+            "description": "The implementations /info data."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "description": "A list of unique errors"
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            },
+            "description": "A list of unique included resources"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
+      "JsonApi": {
+        "title": "JsonApi",
+        "type": "object",
+        "properties": {
+          "version": {
+            "title": "Version",
+            "type": "string",
+            "description": "Version of the json API used",
+            "default": "1.0"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "Non-standard meta information"
+          }
+        },
+        "description": "An object describing the server's implementation"
+      },
+      "Link": {
+        "title": "Link",
+        "required": [
+          "href"
+        ],
+        "type": "object",
+        "properties": {
+          "href": {
+            "title": "Href",
+            "maxLength": 65536,
+            "minLength": 1,
+            "type": "string",
+            "description": "a string containing the link\u2019s URL.",
+            "format": "uri"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the link."
+          }
+        },
+        "description": "A link **MUST** be represented as either: a string containing the link's URL or a link object."
+      },
+      "LinkType": {
+        "title": "LinkType",
+        "enum": [
+          "child",
+          "root",
+          "external",
+          "providers"
+        ],
+        "description": "Enumeration of link_type values"
+      },
+      "LinksResource": {
+        "title": "LinksResource",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          },
+          "type": {
+            "title": "Type",
+            "pattern": "^links$",
+            "type": "string",
+            "description": "These objects are described in detail in the section Links Endpoint",
+            "default": "links"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "title": "Attributes",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinksResourceAttributes"
+              }
+            ],
+            "description": "A dictionary containing key-value pairs representing the Links resource's properties."
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryRelationships"
+              }
+            ],
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
+          }
+        },
+        "description": "A Links endpoint resource object"
+      },
+      "LinksResourceAttributes": {
+        "title": "LinksResourceAttributes",
+        "required": [
+          "name",
+          "description",
+          "base_url",
+          "homepage",
+          "link_type"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "Human-readable name for the OPTIMADE API implementation, e.g., for use in clients to show the name to the end-user."
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "Human-readable description for the OPTIMADE API implementation, e.g., for use in clients to show a description to the end-user."
+          },
+          "base_url": {
+            "title": "Base Url",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "JSON API links object, pointing to the base URL for this implementation"
+          },
+          "homepage": {
+            "title": "Homepage",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "JSON API links object, pointing to a homepage URL for this implementation"
+          },
+          "link_type": {
+            "title": "Link Type",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkType"
+              }
+            ],
+            "description": "The type of the linked relation.\nMUST be one of these values: 'child', 'root', 'external', 'providers'."
+          },
+          "aggregate": {
+            "title": "Aggregate",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Aggregate"
+              }
+            ],
+            "description": "A string indicating whether a client that is following links to aggregate results from different OPTIMADE implementations should follow this link or not.\nThis flag SHOULD NOT be indicated for links where `link_type` is not `child`.\n\nIf not specified, clients MAY assume that the value is `ok`.\nIf specified, and the value is anything different than `ok`, the client MUST assume that the server is suggesting not to follow the link during aggregation by default (also if the value is not among the known ones, in case a future specification adds new accepted values).\n\nSpecific values indicate the reason why the server is providing the suggestion.\nA client MAY follow the link anyway if it has reason to do so (e.g., if the client is looking for all test databases, it MAY follow the links marked with `aggregate`=`test`).\n\nIf specified, it MUST be one of the values listed in section Link Aggregate Options.",
+            "default": "ok"
+          },
+          "no_aggregate_reason": {
+            "title": "No Aggregate Reason",
+            "type": "string",
+            "description": "An OPTIONAL human-readable string indicating the reason for suggesting not to aggregate results following the link.\nIt SHOULD NOT be present if `aggregate`=`ok`."
+          }
+        },
+        "description": "Links endpoint resource object attributes"
+      },
+      "LinksResponse": {
+        "title": "LinksResponse",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/LinksResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ],
+            "description": "List of unique OPTIMADE links resource objects."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "description": "A list of unique errors"
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
+      "Meta": {
+        "title": "Meta",
+        "type": "object",
+        "properties": {},
+        "description": "Non-standard meta-information that can not be represented as an attribute or relationship."
+      },
+      "OptimadeError": {
+        "title": "OptimadeError",
+        "required": [
+          "detail"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string",
+            "description": "the HTTP status code applicable to this problem, expressed as a string value."
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          }
+        },
+        "description": "detail MUST be present"
+      },
+      "Periodicity": {
+        "title": "Periodicity",
+        "enum": [
+          0,
+          1
+        ],
+        "type": "integer",
+        "description": "Integer enumeration of dimension_types values"
+      },
+      "Person": {
+        "title": "Person",
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "Full name of the person, REQUIRED.",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
+          },
+          "firstname": {
+            "title": "Firstname",
+            "type": "string",
+            "description": "First name of the person.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "lastname": {
+            "title": "Lastname",
+            "type": "string",
+            "description": "Last name of the person.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          }
+        },
+        "description": "A person, i.e., an author, editor or other."
+      },
+      "Provider": {
+        "title": "Provider",
+        "required": [
+          "name",
+          "description",
+          "prefix"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "a short name for the database provider"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "a longer description of the database provider"
+          },
+          "prefix": {
+            "title": "Prefix",
+            "pattern": "^[a-z]([a-z]|[0-9]|_)*$",
+            "type": "string",
+            "description": "database-provider-specific prefix as found in section Database-Provider-Specific Namespace Prefixes."
+          },
+          "homepage": {
+            "title": "Homepage",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to homepage of the database provider, either directly as a string, or as a link object."
+          }
+        },
+        "description": "Information on the database provider of the implementation."
+      },
+      "ReferenceRelationship": {
+        "title": "ReferenceRelationship",
+        "type": "object",
+        "properties": {
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RelationshipLinks"
+              }
+            ],
+            "description": "a links object containing at least one of the following: self, related"
+          },
+          "data": {
+            "title": "Data",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BaseRelationshipResource"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BaseRelationshipResource"
+                }
+              }
+            ],
+            "description": "Resource linkage"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object that contains non-standard meta-information about the relationship."
+          }
+        },
+        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."
+      },
+      "ReferenceResource": {
+        "title": "ReferenceResource",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          },
+          "type": {
+            "title": "Type",
+            "pattern": "^references$",
+            "type": "string",
+            "description": "The name of the type of an entry.\n- **Type**: string.\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type <type> and ID <id> MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n- **Example**: `\"structures\"`",
+            "default": "references",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/ReferenceResourceAttributes"
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryRelationships"
+              }
+            ],
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
+          }
+        },
+        "description": "The `references` entries describe bibliographic references.\n\nThe following properties are used to provide the bibliographic details:\n\n- **address**, **annote**, **booktitle**, **chapter**, **crossref**, **edition**, **howpublished**, **institution**, **journal**, **key**, **month**, **note**, **number**, **organization**, **pages**, **publisher**, **school**, **series**, **title**, **volume**, **year**: meanings of these properties match the [BibTeX specification](http://bibtexml.sourceforge.net/btxdoc.pdf), values are strings;\n- **bib_type**: type of the reference, corresponding to **type** property in the BibTeX specification, value is string;\n- **authors** and **editors**: lists of *person objects* which are dictionaries with the following keys:\n    - **name**: Full name of the person, REQUIRED.\n    - **firstname**, **lastname**: Parts of the person's name, OPTIONAL.\n- **doi** and **url**: values are strings.\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., any of the properties MAY be `null`.\n    - **Query**: Support for queries on any of these properties is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - Every references entry MUST contain at least one of the properties."
+      },
+      "ReferenceResourceAttributes": {
+        "title": "ReferenceResourceAttributes",
+        "required": [
+          "last_modified"
+        ],
+        "type": "object",
+        "properties": {
+          "immutable_id": {
+            "title": "Immutable Id",
+            "type": "string",
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
+          },
+          "last_modified": {
+            "title": "Last Modified",
+            "type": "string",
+            "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
+            "format": "date-time",
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          },
+          "authors": {
+            "title": "Authors",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Person"
+            },
+            "description": "List of person objects containing the authors of the reference.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "editors": {
+            "title": "Editors",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Person"
+            },
+            "description": "List of person objects containing the editors of the reference.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "doi": {
+            "title": "Doi",
+            "type": "string",
+            "description": "The digital object identifier of the reference.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "url": {
+            "title": "Url",
+            "maxLength": 65536,
+            "minLength": 1,
+            "type": "string",
+            "description": "The URL of the reference.",
+            "format": "uri",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "address": {
+            "title": "Address",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "annote": {
+            "title": "Annote",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "booktitle": {
+            "title": "Booktitle",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "chapter": {
+            "title": "Chapter",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "crossref": {
+            "title": "Crossref",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "edition": {
+            "title": "Edition",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "howpublished": {
+            "title": "Howpublished",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "institution": {
+            "title": "Institution",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "journal": {
+            "title": "Journal",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "key": {
+            "title": "Key",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "month": {
+            "title": "Month",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "note": {
+            "title": "Note",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "number": {
+            "title": "Number",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "organization": {
+            "title": "Organization",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "pages": {
+            "title": "Pages",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "publisher": {
+            "title": "Publisher",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "school": {
+            "title": "School",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "series": {
+            "title": "Series",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "bib_type": {
+            "title": "Bib Type",
+            "type": "string",
+            "description": "Type of the reference, corresponding to the **type** property in the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "volume": {
+            "title": "Volume",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "year": {
+            "title": "Year",
+            "type": "string",
+            "description": "Meaning of property matches the BiBTeX specification.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          }
+        },
+        "description": "Model that stores the attributes of a reference.\n\nMany properties match the meaning described in the\n[BibTeX specification](http://bibtexml.sourceforge.net/btxdoc.pdf)."
+      },
+      "ReferenceResponseMany": {
+        "title": "ReferenceResponseMany",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ReferenceResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ],
+            "description": "List of unique OPTIMADE references entry resource objects."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "description": "A list of unique errors"
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
+      "ReferenceResponseOne": {
+        "title": "ReferenceResponseOne",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceResource"
+              },
+              {
+                "type": "object"
+              }
+            ],
+            "description": "A single references entry resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "description": "A list of unique errors"
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
+      "RelationshipLinks": {
+        "title": "RelationshipLinks",
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "Self",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A link for the relationship itself (a 'relationship link').\nThis link allows the client to directly manipulate the relationship.\nWhen fetched successfully, this link returns the [linkage](https://jsonapi.org/format/1.0/#document-resource-object-linkage) for the related resources as its primary data.\n(See [Fetching Relationships](https://jsonapi.org/format/1.0/#fetching-relationships).)"
+          },
+          "related": {
+            "title": "Related",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A [related resource link](https://jsonapi.org/format/1.0/#document-resource-object-related-resource-links)."
+          }
+        },
+        "description": "A resource object **MAY** contain references to other resource objects (\"relationships\").\nRelationships may be to-one or to-many.\nRelationships can be specified by including a member in a resource's links object."
+      },
+      "Relationships": {
+        "title": "Relationships",
+        "type": "object",
+        "properties": {},
+        "description": "Members of the relationships object (\"relationships\") represent references from the resource object in which it's defined to other resource objects.\nKeys MUST NOT be:\n    type\n    id"
+      },
+      "Resource": {
+        "title": "Resource",
+        "required": [
+          "id",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "Resource ID"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "Resource type"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "title": "Attributes",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Attributes"
+              }
+            ],
+            "description": "an attributes object representing some of the resource\u2019s data."
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Relationships"
+              }
+            ],
+            "description": "[Relationships object](https://jsonapi.org/format/1.0/#document-resource-object-relationships)\ndescribing relationships between the resource and other JSON API resources."
+          }
+        },
+        "description": "Resource objects appear in a JSON API document to represent resources."
+      },
+      "ResourceLinks": {
+        "title": "ResourceLinks",
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "Self",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A link that identifies the resource represented by the resource object."
+          }
+        },
+        "description": "A Resource Links object"
+      },
+      "ResponseMeta": {
+        "title": "ResponseMeta",
+        "required": [
+          "query",
+          "api_version",
+          "more_data_available"
+        ],
+        "type": "object",
+        "properties": {
+          "query": {
+            "title": "Query",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMetaQuery"
+              }
+            ],
+            "description": "Information on the Query that was requested"
+          },
+          "api_version": {
+            "title": "Api Version",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+            "type": "string",
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "example": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
+          },
+          "more_data_available": {
+            "title": "More Data Available",
+            "type": "boolean",
+            "description": "`false` if the response contains all data for the request (e.g., a request issued to a single entry endpoint, or a `filter` query at the last page of a paginated response) and `true` if the response is incomplete in the sense that multiple objects match the request, and not all of them have been included in the response (e.g., a query with multiple pages that is not at the last page)."
+          },
+          "schema": {
+            "title": "Schema",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.\nIf it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema.\nIt is possible that future versions of this specification allows for alternative schema types.\nHence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
+          },
+          "time_stamp": {
+            "title": "Time Stamp",
+            "type": "string",
+            "description": "A timestamp containing the date and time at which the query was executed.",
+            "format": "date-time"
+          },
+          "data_returned": {
+            "title": "Data Returned",
+            "minimum": 0.0,
+            "type": "integer",
+            "description": "An integer containing the total number of data resource objects returned for the current `filter` query, independent of pagination."
+          },
+          "provider": {
+            "title": "Provider",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Provider"
+              }
+            ],
+            "description": "information on the database provider of the implementation."
+          },
+          "data_available": {
+            "title": "Data Available",
+            "type": "integer",
+            "description": "An integer containing the total number of data resource objects available in the database for the endpoint."
+          },
+          "last_id": {
+            "title": "Last Id",
+            "type": "string",
+            "description": "a string containing the last ID returned"
+          },
+          "response_message": {
+            "title": "Response Message",
+            "type": "string",
+            "description": "response string from the server"
+          },
+          "implementation": {
+            "title": "Implementation",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Implementation"
+              }
+            ],
+            "description": "a dictionary describing the server implementation"
+          },
+          "warnings": {
+            "title": "Warnings",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Warnings"
+            },
+            "description": "A list of warning resource objects representing non-critical errors or warnings.\nA warning resource object is defined similarly to a [JSON API error object](http://jsonapi.org/format/1.0/#error-objects), but MUST also include the field `type`, which MUST have the value `\"warning\"`.\nThe field `detail` MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\nThe field `status`, representing a HTTP response status code, MUST NOT be present for a warning resource object.\nThis is an exclusive field for error resource objects."
+          }
+        },
+        "description": "A [JSON API meta member](https://jsonapi.org/format/1.0#document-meta)\nthat contains JSON API meta objects of non-standard\nmeta-information.\n\nOPTIONAL additional information global to the query that is not\nspecified in this document, MUST start with a\ndatabase-provider-specific prefix."
+      },
+      "ResponseMetaQuery": {
+        "title": "ResponseMetaQuery",
+        "required": [
+          "representation"
+        ],
+        "type": "object",
+        "properties": {
+          "representation": {
+            "title": "Representation",
+            "type": "string",
+            "description": "A string with the part of the URL following the versioned or unversioned base URL that serves the API.\nQuery parameters that have not been used in processing the request MAY be omitted.\nIn particular, if no query parameters have been involved in processing the request, the query part of the URL MAY be excluded.\nExample: `/structures?filter=nelements=2`"
+          }
+        },
+        "description": "Information on the query that was requested."
+      },
+      "Species": {
+        "title": "Species",
+        "required": [
+          "name",
+          "chemical_symbols",
+          "concentration"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "Gives the name of the species; the **name** value MUST be unique in the `species` list.",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
+          },
+          "chemical_symbols": {
+            "title": "Chemical Symbols",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "MUST be a list of strings of all chemical elements composing this species. Each item of the list MUST be one of the following:\n\n- a valid chemical-element symbol, or\n- the special value `\"X\"` to represent a non-chemical element, or\n- the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\nIf any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`.",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
+          },
+          "concentration": {
+            "title": "Concentration",
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "MUST be a list of floats, with same length as `chemical_symbols`. The numbers represent the relative concentration of the corresponding chemical symbol in this species. The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n- Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n- Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\nNote that concentrations are uncorrelated between different site (even of the same species).",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
+          },
+          "mass": {
+            "title": "Mass",
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "If present MUST be a list of floats expressed in a.m.u.\nElements denoting vacancies MUST have masses equal to 0.",
+            "x-optimade-unit": "a.m.u.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "original_name": {
+            "title": "Original Name",
+            "type": "string",
+            "description": "Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\nNote: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "attached": {
+            "title": "Attached",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "If provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "nattached": {
+            "title": "Nattached",
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "If provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the :field:`attached` key.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          }
+        },
+        "description": "A list describing the species of the sites of this structure.\n\nSpecies can represent pure chemical elements, virtual-crystal atoms representing a\nstatistical occupation of a given site by multiple chemical elements, and/or a\nlocation to which there are attached atoms, i.e., atoms whose precise location are\nunknown beyond that they are attached to that position (frequently used to indicate\nhydrogen atoms attached to another element, e.g., a carbon with three attached\nhydrogens might represent a methyl group, -CH3).\n\n- **Examples**:\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - `[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": [0.0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - `[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - `[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.\n    - `[ {\"name\": \"CH3\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"attached\": [\"H\"], \"nattached\": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms."
+      },
+      "StructureFeatures": {
+        "title": "StructureFeatures",
+        "enum": [
+          "disorder",
+          "implicit_atoms",
+          "site_attachments",
+          "assemblies"
+        ],
+        "description": "Enumeration of structure_features values"
+      },
+      "StructureRelationship": {
+        "title": "StructureRelationship",
+        "type": "object",
+        "properties": {
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RelationshipLinks"
+              }
+            ],
+            "description": "a links object containing at least one of the following: self, related"
+          },
+          "data": {
+            "title": "Data",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BaseRelationshipResource"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BaseRelationshipResource"
+                }
+              }
+            ],
+            "description": "Resource linkage"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object that contains non-standard meta-information about the relationship."
+          }
+        },
+        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."
+      },
+      "StructureResource": {
+        "title": "StructureResource",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          },
+          "type": {
+            "title": "Type",
+            "pattern": "^structures$",
+            "type": "string",
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Examples**:\n    - `\"structures\"`",
+            "default": "structures",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/StructureResourceAttributes"
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryRelationships"
+              }
+            ],
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
+          }
+        },
+        "description": "Representing a structure."
+      },
+      "StructureResourceAttributes": {
+        "title": "StructureResourceAttributes",
+        "required": [
+          "last_modified",
+          "elements",
+          "nelements",
+          "elements_ratios",
+          "chemical_formula_descriptive",
+          "chemical_formula_reduced",
+          "chemical_formula_anonymous",
+          "dimension_types",
+          "nperiodic_dimensions",
+          "lattice_vectors",
+          "cartesian_site_positions",
+          "nsites",
+          "species",
+          "species_at_sites",
+          "structure_features"
+        ],
+        "type": "object",
+        "properties": {
+          "immutable_id": {
+            "title": "Immutable Id",
+            "type": "string",
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
+          },
+          "last_modified": {
+            "title": "Last Modified",
+            "type": "string",
+            "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
+            "format": "date-time",
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          },
+          "elements": {
+            "title": "Elements",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The chemical symbols of the different elements present in the structure.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The strings are the chemical symbols, i.e., either a single uppercase letter or an uppercase letter followed by a number of lowercase letters.\n    - The order MUST be alphabetical.\n    - MUST refer to the same elements in the same order, and therefore be of the same length, as `elements_ratios`, if the latter is provided.\n    - Note: This property SHOULD NOT contain the string \"X\" to indicate non-chemical elements or \"vacancy\" to indicate vacancies (in contrast to the field `chemical_symbols` for the `species` property).\n\n- **Examples**:\n    - `[\"Si\"]`\n    - `[\"Al\",\"O\",\"Si\"]`\n\n- **Query examples**:\n    - A filter that matches all records of structures that contain Si, Al **and** O, and possibly other elements: `elements HAS ALL \"Si\", \"Al\", \"O\"`.\n    - To match structures with exactly these three elements, use `elements HAS ALL \"Si\", \"Al\", \"O\" AND elements LENGTH 3`.\n    - Note: length queries on this property can be equivalently formulated by filtering on the `nelements`_ property directly.",
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          },
+          "nelements": {
+            "title": "Nelements",
+            "type": "integer",
+            "description": "Number of different elements in the structure as an integer.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - MUST be equal to the lengths of the list properties `elements` and `elements_ratios`, if they are provided.\n\n- **Examples**:\n    - `3`\n\n- **Querying**:\n    - Note: queries on this property can equivalently be formulated using `elements LENGTH`.\n    - A filter that matches structures that have exactly 4 elements: `nelements=4`.\n    - A filter that matches structures that have between 2 and 7 elements: `nelements>=2 AND nelements<=7`.",
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          },
+          "elements_ratios": {
+            "title": "Elements Ratios",
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Relative proportions of different elements in the structure.\n\n- **Type**: list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - Composed by the proportions of elements in the structure as a list of floating point numbers.\n    - The sum of the numbers MUST be 1.0 (within floating point accuracy)\n    - MUST refer to the same elements in the same order, and therefore be of the same length, as `elements`, if the latter is provided.\n\n- **Examples**:\n    - `[1.0]`\n    - `[0.3333333333333333, 0.2222222222222222, 0.4444444444444444]`\n\n- **Query examples**:\n    - Note: Useful filters can be formulated using the set operator syntax for correlated values.\n      However, since the values are floating point values, the use of equality comparisons is generally inadvisable.\n    - OPTIONAL: a filter that matches structures where approximately 1/3 of the atoms in the structure are the element Al is: `elements:elements_ratios HAS ALL \"Al\":>0.3333, \"Al\":<0.3334`.",
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          },
+          "chemical_formula_descriptive": {
+            "title": "Chemical Formula Descriptive",
+            "type": "string",
+            "description": "The chemical formula for a structure as a string in a form chosen by the API implementation.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The chemical formula is given as a string consisting of properly capitalized element symbols followed by integers or decimal numbers, balanced parentheses, square, and curly brackets `(`,`)`, `[`,`]`, `{`, `}`, commas, the `+`, `-`, `:` and `=` symbols. The parentheses are allowed to be followed by a number. Spaces are allowed anywhere except within chemical symbols. The order of elements and any groupings indicated by parentheses or brackets are chosen freely by the API implementation.\n    - The string SHOULD be arithmetically consistent with the element ratios in the `chemical_formula_reduced` property.\n    - It is RECOMMENDED, but not mandatory, that symbols, parentheses and brackets, if used, are used with the meanings prescribed by [IUPAC's Nomenclature of Organic Chemistry](https://www.qmul.ac.uk/sbcs/iupac/bibliog/blue.html).\n\n- **Examples**:\n    - `\"(H2O)2 Na\"`\n    - `\"NaCl\"`\n    - `\"CaCO3\"`\n    - `\"CCaO3\"`\n    - `\"(CH3)3N+ - [CH2]2-OH = Me3N+ - CH2 - CH2OH\"`\n\n- **Query examples**:\n    - Note: the free-form nature of this property is likely to make queries on it across different databases inconsistent.\n    - A filter that matches an exactly given formula: `chemical_formula_descriptive=\"(H2O)2 Na\"`.\n    - A filter that does a partial match: `chemical_formula_descriptive CONTAINS \"H2O\"`.",
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          },
+          "chemical_formula_reduced": {
+            "title": "Chemical Formula Reduced",
+            "pattern": "^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
+            "type": "string",
+            "description": "The reduced chemical formula for a structure as a string with element symbols and integer chemical proportion numbers.\nThe proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property.\n      However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n      Intricate queries on formula components are instead suggested to be formulated using set-type filter operators on the multi valued `elements` and `elements_ratios` properties.\n    - Element symbols MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in alphabetical order, followed by their integer chemical proportion number.\n    - For structures with no partial occupation, the chemical proportion numbers are the smallest integers for which the chemical proportion is exactly correct.\n    - For structures with partial occupation, the chemical proportion numbers are integers that within reasonable approximation indicate the correct chemical proportions. The precise details of how to perform the rounding is chosen by the API implementation.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2NaO\"`\n    - `\"ClNa\"`\n    - `\"CCaO3\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_reduced=\"H2NaO\"`.",
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          },
+          "chemical_formula_hill": {
+            "title": "Chemical Formula Hill",
+            "pattern": "^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
+            "type": "string",
+            "description": "The chemical formula for a structure in [Hill form](https://dx.doi.org/10.1021/ja02046a005) with element symbols followed by integer chemical proportion numbers. The proportion number MUST be omitted if it is 1.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, only a subset of the filter features MAY be supported.\n    - The overall scale factor of the chemical proportions is chosen such that the resulting values are integers that indicate the most chemically relevant unit of which the system is composed.\n      For example, if the structure is a repeating unit cell with four hydrogens and four oxygens that represents two hydroperoxide molecules, `chemical_formula_hill` is `\"H2O2\"` (i.e., not `\"HO\"`, nor `\"H4O4\"`).\n    - If the chemical insight needed to ascribe a Hill formula to the system is not present, the property MUST be handled as unset.\n    - Element symbols MUST have proper capitalization (e.g., `\"Si\"`, not `\"SI\"` for \"silicon\").\n    - Elements MUST be placed in [Hill order](https://dx.doi.org/10.1021/ja02046a005), followed by their integer chemical proportion number.\n      Hill order means: if carbon is present, it is placed first, and if also present, hydrogen is placed second.\n      After that, all other elements are ordered alphabetically.\n      If carbon is not present, all elements are ordered alphabetically.\n    - If the system has sites with partial occupation and the total occupations of each element do not all sum up to integers, then the Hill formula SHOULD be handled as unset.\n    - No spaces or separators are allowed.\n\n- **Examples**:\n    - `\"H2O2\"`\n\n- **Query examples**:\n    - A filter that matches an exactly given formula is `chemical_formula_hill=\"H2O2\"`.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "chemical_formula_anonymous": {
+            "title": "Chemical Formula Anonymous",
+            "pattern": "^([A-Z][a-z]?([2-9]|[1-9]\\d+)?)+$",
+            "type": "string",
+            "description": "The anonymous formula is the `chemical_formula_reduced`, but where the elements are instead first ordered by their chemical proportion number, and then, in order left to right, replaced by anonymous symbols A, B, C, ..., Z, Aa, Ba, ..., Za, Ab, Bb, ... and so on.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property.\n      However, support for filters using partial string matching with this property is OPTIONAL (i.e., BEGINS WITH, ENDS WITH, and CONTAINS).\n\n- **Examples**:\n    - `\"A2B\"`\n    - `\"A42B42C16D12E10F9G5\"`\n\n- **Querying**:\n    - A filter that matches an exactly given formula is `chemical_formula_anonymous=\"A2B\"`.",
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          },
+          "dimension_types": {
+            "title": "Dimension Types",
+            "maxItems": 3,
+            "minItems": 3,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Periodicity"
+            },
+            "description": "List of three integers.\nFor each of the three directions indicated by the three lattice vectors (see property `lattice_vectors`), this list indicates if the direction is periodic (value `1`) or non-periodic (value `0`).\nNote: the elements in this list each refer to the direction of the corresponding entry in `lattice_vectors` and *not* the Cartesian x, y, z directions.\n\n- **Type**: list of integers.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n    - MUST be a list of length 3.\n    - Each integer element MUST assume only the value 0 or 1.\n\n- **Examples**:\n    - For a molecule: `[0, 0, 0]`\n    - For a wire along the direction specified by the third lattice vector: `[0, 0, 1]`\n    - For a 2D surface/slab, periodic on the plane defined by the first and third lattice vectors: `[1, 0, 1]`\n    - For a bulk 3D system: `[1, 1, 1]`",
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
+          },
+          "nperiodic_dimensions": {
+            "title": "Nperiodic Dimensions",
+            "type": "integer",
+            "description": "An integer specifying the number of periodic dimensions in the structure, equivalent to the number of non-zero entries in `dimension_types`.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - The integer value MUST be between 0 and 3 inclusive and MUST be equal to the sum of the items in the `dimension_types` property.\n    - This property only reflects the treatment of the lattice vectors provided for the structure, and not any physical interpretation of the dimensionality of its contents.\n\n- **Examples**:\n    - `2` should be indicated in cases where `dimension_types` is any of `[1, 1, 0]`, `[1, 0, 1]`, `[0, 1, 1]`.\n\n- **Query examples**:\n    - Match only structures with exactly 3 periodic dimensions: `nperiodic_dimensions=3`\n    - Match all structures with 2 or fewer periodic dimensions: `nperiodic_dimensions<=2`",
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          },
+          "lattice_vectors": {
+            "title": "Lattice Vectors",
+            "maxItems": 3,
+            "minItems": 3,
+            "type": "array",
+            "items": {
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "description": "The three lattice vectors in Cartesian coordinates, in \u00e5ngstr\u00f6m (\u00c5).\n\n- **Type**: list of list of floats or unknown values.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST be a list of three vectors *a*, *b*, and *c*, where each of the vectors MUST BE a list of the vector's coordinates along the x, y, and z Cartesian coordinates.\n      (Therefore, the first index runs over the three lattice vectors and the second index runs over the x, y, z Cartesian coordinates).\n    - For databases that do not define an absolute Cartesian system (e.g., only defining the length and angles between vectors), the first lattice vector SHOULD be set along *x* and the second on the *xy*-plane.\n    - MUST always contain three vectors of three coordinates each, independently of the elements of property `dimension_types`.\n      The vectors SHOULD by convention be chosen so the determinant of the `lattice_vectors` matrix is different from zero.\n      The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.\n    - The coordinates of the lattice vectors of non-periodic dimensions (i.e., those dimensions for which `dimension_types` is `0`) MAY be given as a list of all `null` values.\n        If a lattice vector contains the value `null`, all coordinates of that lattice vector MUST be `null`.\n\n- **Examples**:\n    - `[[4.0,0.0,0.0],[0.0,4.0,0.0],[0.0,1.0,4.0]]` represents a cell, where the first vector is `(4, 0, 0)`, i.e., a vector aligned along the `x` axis of length 4 \u00c5; the second vector is `(0, 4, 0)`; and the third vector is `(0, 1, 4)`.",
+            "nullable": true,
+            "x-optimade-unit": "\u00c5",
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
+          },
+          "cartesian_site_positions": {
+            "title": "Cartesian Site Positions",
+            "type": "array",
+            "items": {
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "description": "Cartesian positions of each site in the structure.\nA site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the `species_at_sites` property, and the species themselves are described in the `species` property.\n\n- **Type**: list of list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - It MUST be a list of length equal to the number of sites in the structure, where every element is a list of the three Cartesian coordinates of a site expressed as float values in the unit angstrom (\u00c5).\n    - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`).\n\n- **Examples**:\n    - `[[0,0,0],[0,0,2]]` indicates a structure with two sites, one sitting at the origin and one along the (positive) *z*-axis, 2 \u00c5 away from the origin.",
+            "nullable": true,
+            "x-optimade-unit": "\u00c5",
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
+          },
+          "nsites": {
+            "title": "Nsites",
+            "type": "integer",
+            "description": "An integer specifying the length of the `cartesian_site_positions` property.\n\n- **Type**: integer\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `42`\n\n- **Query examples**:\n    - Match only structures with exactly 4 sites: `nsites=4`\n    - Match structures that have between 2 and 7 sites: `nsites>=2 AND nsites<=7`",
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          },
+          "species": {
+            "title": "Species",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Species"
+            },
+            "description": "A list describing the species of the sites of this structure.\nSpecies can represent pure chemical elements, virtual-crystal atoms representing a statistical occupation of a given site by multiple chemical elements, and/or a location to which there are attached atoms, i.e., atoms whose precise location are unknown beyond that they are attached to that position (frequently used to indicate hydrogen atoms attached to another element, e.g., a carbon with three attached hydrogens might represent a methyl group, -CH3).\n\n- **Type**: list of dictionary with keys:\n    - `name`: string (REQUIRED)\n    - `chemical_symbols`: list of strings (REQUIRED)\n    - `concentration`: list of float (REQUIRED)\n    - `attached`: list of strings (REQUIRED)\n    - `nattached`: list of integers (OPTIONAL)\n    - `mass`: list of floats (OPTIONAL)\n    - `original_name`: string (OPTIONAL).\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - Each list member MUST be a dictionary with the following keys:\n        - **name**: REQUIRED; gives the name of the species; the **name** value MUST be unique in the `species` list;\n        - **chemical_symbols**: REQUIRED; MUST be a list of strings of all chemical elements composing this species.\n          Each item of the list MUST be one of the following:\n            - a valid chemical-element symbol, or\n            - the special value `\"X\"` to represent a non-chemical element, or\n            - the special value `\"vacancy\"` to represent that this site has a non-zero probability of having a vacancy (the respective probability is indicated in the `concentration` list, see below).\n\n          If any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element, the correct flag MUST be set in the list `structure_features`.\n\n        - **concentration**: REQUIRED; MUST be a list of floats, with same length as `chemical_symbols`.\n          The numbers represent the relative concentration of the corresponding chemical symbol in this species.\n          The numbers SHOULD sum to one. Cases in which the numbers do not sum to one typically fall only in the following two categories:\n\n            - Numerical errors when representing float numbers in fixed precision, e.g. for two chemical symbols with concentrations `1/3` and `2/3`, the concentration might look something like `[0.33333333333, 0.66666666666]`. If the client is aware that the sum is not one because of numerical precision, it can renormalize the values so that the sum is exactly one.\n            - Experimental errors in the data present in the database. In this case, it is the responsibility of the client to decide how to process the data.\n\n            Note that concentrations are uncorrelated between different sites (even of the same species).\n\n        - **attached**: OPTIONAL; if provided MUST be a list of length 1 or more of strings of chemical symbols for the elements attached to this site, or \"X\" for a non-chemical element.\n\n        - **nattached**: OPTIONAL; if provided MUST be a list of length 1 or more of integers indicating the number of attached atoms of the kind specified in the value of the `attached` key.\n\n          The implementation MUST include either both or none of the `attached` and `nattached` keys, and if they are provided, they MUST be of the same length.\n          Furthermore, if they are provided, the `structure_features` property MUST include the string `site_attachments`.\n\n        - **mass**: OPTIONAL. If present MUST be a list of floats, with the same length as `chemical_symbols`, providing element masses expressed in a.m.u.\n          Elements denoting vacancies MUST have masses equal to 0.\n\n        - **original_name**: OPTIONAL. Can be any valid Unicode string, and SHOULD contain (if specified) the name of the species that is used internally in the source database.\n\n          Note: With regards to \"source database\", we refer to the immediate source being queried via the OPTIMADE API implementation.\n\n          The main use of this field is for source databases that use species names, containing characters that are not allowed (see description of the list property `species_at_sites`).\n\n    - For systems that have only species formed by a single chemical symbol, and that have at most one species per chemical symbol, SHOULD use the chemical symbol as species name (e.g., `\"Ti\"` for titanium, `\"O\"` for oxygen, etc.)\n      However, note that this is OPTIONAL, and client implementations MUST NOT assume that the key corresponds to a chemical symbol, nor assume that if the species name is a valid chemical symbol, that it represents a species with that chemical symbol.\n      This means that a species `{\"name\": \"C\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]}` is valid and represents a titanium species (and *not* a carbon species).\n    - It is NOT RECOMMENDED that a structure includes species that do not have at least one corresponding site.\n\n- **Examples**:\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\"], \"concentration\": [1.0]} ]`: any site with this species is occupied by a Ti atom.\n    - `[ {\"name\": \"Ti\", \"chemical_symbols\": [\"Ti\", \"vacancy\"], \"concentration\": [0.9, 0.1]} ]`: any site with this species is occupied by a Ti atom with 90 % probability, and has a vacancy with 10 % probability.\n    - `[ {\"name\": \"BaCa\", \"chemical_symbols\": [\"vacancy\", \"Ba\", \"Ca\"], \"concentration\": [0.05, 0.45, 0.5], \"mass\": [0.0, 137.327, 40.078]} ]`: any site with this species is occupied by a Ba atom with 45 % probability, a Ca atom with 50 % probability, and by a vacancy with 5 % probability. The mass of this site is (on average) 88.5 a.m.u.\n    - `[ {\"name\": \"C12\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [12.0]} ]`: any site with this species is occupied by a carbon isotope with mass 12.\n    - `[ {\"name\": \"C13\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"mass\": [13.0]} ]`: any site with this species is occupied by a carbon isotope with mass 13.\n    - `[ {\"name\": \"CH3\", \"chemical_symbols\": [\"C\"], \"concentration\": [1.0], \"attached\": [\"H\"], \"nattached\": [3]} ]`: any site with this species is occupied by a methyl group, -CH3, which is represented without specifying precise positions of the hydrogen atoms.",
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
+          },
+          "species_at_sites": {
+            "title": "Species At Sites",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Name of the species at each site (where values for sites are specified with the same order of the property `cartesian_site_positions`).\nThe properties of the species are found in the property `species`.\n\n- **Type**: list of strings.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST have length equal to the number of sites in the structure (first dimension of the list property `cartesian_site_positions`).\n    - Each species name mentioned in the `species_at_sites` list MUST be described in the list property `species` (i.e. for each value in the `species_at_sites` list there MUST exist exactly one dictionary in the `species` list with the `name` attribute equal to the corresponding `species_at_sites` value).\n    - Each site MUST be associated only to a single species.\n      **Note**: However, species can represent mixtures of atoms, and multiple species MAY be defined for the same chemical element.\n      This latter case is useful when different atoms of the same type need to be grouped or distinguished, for instance in simulation codes to assign different initial spin states.\n\n- **Examples**:\n    - `[\"Ti\",\"O2\"]` indicates that the first site is hosting a species labeled `\"Ti\"` and the second a species labeled `\"O2\"`.\n    - `[\"Ac\", \"Ac\", \"Ag\", \"Ir\"]` indicating the first two sites contains the `\"Ac\"` species, while the third and fourth sites contain the `\"Ag\"` and `\"Ir\"` species, respectively.",
+            "nullable": true,
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "optional"
+          },
+          "assemblies": {
+            "title": "Assemblies",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Assembly"
+            },
+            "description": "A description of groups of sites that are statistically correlated.\n\n- **Type**: list of dictionary with keys:\n    - `sites_in_groups`: list of list of integers (REQUIRED)\n    - `group_probabilities`: list of floats (REQUIRED)\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n        If supported, filters MAY support only a subset of comparison operators.\n    - The property SHOULD be `null` for entries that have no partial occupancies.\n    - If present, the correct flag MUST be set in the list `structure_features`.\n    - Client implementations MUST check its presence (as its presence changes the interpretation of the structure).\n    - If present, it MUST be a list of dictionaries, each of which represents an assembly and MUST have the following two keys:\n        - **sites_in_groups**: Index of the sites (0-based) that belong to each group for each assembly.\n\n            Example: `[[1], [2]]`: two groups, one with the second site, one with the third.\n            Example: `[[1,2], [3]]`: one group with the second and third site, one with the fourth.\n\n        - **group_probabilities**: Statistical probability of each group. It MUST have the same length as `sites_in_groups`.\n            It SHOULD sum to one.\n            See below for examples of how to specify the probability of the occurrence of a vacancy.\n            The possible reasons for the values not to sum to one are the same as already specified above for the `concentration` of each `species`.\n\n    - If a site is not present in any group, it means that it is present with 100 % probability (as if no assembly was specified).\n    - A site MUST NOT appear in more than one group.\n\n- **Examples** (for each entry of the assemblies list):\n    - `{\"sites_in_groups\": [[0], [1]], \"group_probabilities: [0.3, 0.7]}`: the first site and the second site never occur at the same time in the unit cell.\n        Statistically, 30 % of the times the first site is present, while 70 % of the times the second site is present.\n    - `{\"sites_in_groups\": [[1,2], [3]], \"group_probabilities: [0.3, 0.7]}`: the second and third site are either present together or not present; they form the first group of atoms for this assembly.\n        The second group is formed by the fourth site.\n        Sites of the first group (the second and the third) are never present at the same time as the fourth site.\n        30 % of times sites 1 and 2 are present (and site 3 is absent); 70 % of times site 3 is present (and sites 1 and 2 are absent).\n\n- **Notes**:\n    - Assemblies are essential to represent, for instance, the situation where an atom can statistically occupy two different positions (sites).\n\n    - By defining groups, it is possible to represent, e.g., the case where a functional molecule (and not just one atom) is either present or absent (or the case where it it is present in two conformations)\n\n    - Considerations on virtual alloys and on vacancies: In the special case of a virtual alloy, these specifications allow two different, equivalent ways of specifying them.\n        For instance, for a site at the origin with 30 % probability of being occupied by Si, 50 % probability of being occupied by Ge, and 20 % of being a vacancy, the following two representations are possible:\n\n        - Using a single species:\n            ```json\n            {\n              \"cartesian_site_positions\": [[0,0,0]],\n              \"species_at_sites\": [\"SiGe-vac\"],\n              \"species\": [\n              {\n                \"name\": \"SiGe-vac\",\n                \"chemical_symbols\": [\"Si\", \"Ge\", \"vacancy\"],\n                \"concentration\": [0.3, 0.5, 0.2]\n              }\n              ]\n              // ...\n            }\n            ```\n\n        - Using multiple species and the assemblies:\n            ```json\n            {\n              \"cartesian_site_positions\": [ [0,0,0], [0,0,0], [0,0,0] ],\n              \"species_at_sites\": [\"Si\", \"Ge\", \"vac\"],\n              \"species\": [\n                { \"name\": \"Si\", \"chemical_symbols\": [\"Si\"], \"concentration\": [1.0] },\n                { \"name\": \"Ge\", \"chemical_symbols\": [\"Ge\"], \"concentration\": [1.0] },\n                { \"name\": \"vac\", \"chemical_symbols\": [\"vacancy\"], \"concentration\": [1.0] }\n              ],\n              \"assemblies\": [\n                {\n              \"sites_in_groups\": [ [0], [1], [2] ],\n              \"group_probabilities\": [0.3, 0.5, 0.2]\n                }\n              ]\n              // ...\n            }\n            ```\n\n    - It is up to the database provider to decide which representation to use, typically depending on the internal format in which the structure is stored.\n        However, given a structure identified by a unique ID, the API implementation MUST always provide the same representation for it.\n\n    - The probabilities of occurrence of different assemblies are uncorrelated.\n        So, for instance in the following case with two assemblies:\n        ```json\n        {\n          \"assemblies\": [\n            {\n              \"sites_in_groups\": [ [0], [1] ],\n              \"group_probabilities\": [0.2, 0.8],\n            },\n            {\n              \"sites_in_groups\": [ [2], [3] ],\n              \"group_probabilities\": [0.3, 0.7]\n            }\n          ]\n        }\n        ```\n\n        Site 0 is present with a probability of 20 % and site 1 with a probability of 80 %. These two sites are correlated (either site 0 or 1 is present). Similarly, site 2 is present with a probability of 30 % and site 3 with a probability of 70 %.\n        These two sites are correlated (either site 2 or 3 is present).\n        However, the presence or absence of sites 0 and 1 is not correlated with the presence or absence of sites 2 and 3 (in the specific example, the pair of sites (0, 2) can occur with 0.2*0.3 = 6 % probability; the pair (0, 3) with 0.2*0.7 = 14 % probability; the pair (1, 2) with 0.8*0.3 = 24 % probability; and the pair (1, 3) with 0.8*0.7 = 56 % probability).",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "structure_features": {
+            "title": "Structure Features",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StructureFeatures"
+            },
+            "description": "A list of strings that flag which special features are used by the structure.\n\n- **Type**: list of strings\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property.\n    Filters on the list MUST support all mandatory HAS-type queries.\n    Filter operators for comparisons on the string components MUST support equality, support for other comparison operators are OPTIONAL.\n    - MUST be an empty list if no special features are used.\n    - MUST be sorted alphabetically.\n    - If a special feature listed below is used, the list MUST contain the corresponding string.\n    - If a special feature listed below is not used, the list MUST NOT contain the corresponding string.\n    - **List of strings used to indicate special structure features**:\n        - `disorder`: this flag MUST be present if any one entry in the `species` list has a `chemical_symbols` list that is longer than 1 element.\n        - `implicit_atoms`: this flag MUST be present if the structure contains atoms that are not assigned to sites via the property `species_at_sites` (e.g., because their positions are unknown).\n           When this flag is present, the properties related to the chemical formula will likely not match the type and count of atoms represented by the `species_at_sites`, `species` and `assemblies` properties.\n        - `site_attachments`: this flag MUST be present if any one entry in the `species` list includes `attached` and `nattached`.\n        - `assemblies`: this flag MUST be present if the property `assemblies` is present.\n\n- **Examples**: A structure having implicit atoms and using assemblies: `[\"assemblies\", \"implicit_atoms\"]`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          }
+        },
+        "description": "This class contains the Field for the attributes used to represent a structure, e.g. unit cell, atoms, positions."
+      },
+      "StructureResponseMany": {
+        "title": "StructureResponseMany",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/StructureResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ],
+            "description": "List of unique OPTIMADE structures entry resource objects."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "description": "A list of unique errors"
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
+      "StructureResponseOne": {
+        "title": "StructureResponseOne",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StructureResource"
+              },
+              {
+                "type": "object"
+              }
+            ],
+            "description": "A single structures entry resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "description": "A list of unique errors"
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
+      "ToplevelLinks": {
+        "title": "ToplevelLinks",
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "Self",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A link to itself"
+          },
+          "related": {
+            "title": "Related",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A related resource link"
+          },
+          "first": {
+            "title": "First",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The first page of data"
+          },
+          "last": {
+            "title": "Last",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The last page of data"
+          },
+          "prev": {
+            "title": "Prev",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The previous page of data"
+          },
+          "next": {
+            "title": "Next",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The next page of data"
+          }
+        },
+        "description": "A set of Links objects, possibly including pagination"
+      },
+      "Warnings": {
+        "title": "Warnings",
+        "required": [
+          "detail",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          },
+          "type": {
+            "title": "Type",
+            "pattern": "^warning$",
+            "type": "string",
+            "description": "Warnings must be of type \"warning\"",
+            "default": "warning"
+          }
+        },
+        "description": "OPTIMADE-specific warning class based on OPTIMADE-specific JSON API Error.\n\nFrom the specification:\n\nA warning resource object is defined similarly to a JSON API error object, but MUST also include the field type, which MUST have the value \"warning\".\nThe field detail MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\n\nNote: Must be named \"Warnings\", since \"Warning\" is a built-in Python class."
+      }
+    }
+  }
+}

--- a/openapi/v1.2.0/optimade.json
+++ b/openapi/v1.2.0/optimade.json
@@ -2,8 +2,8 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTIMADE API",
-    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.19.5) v0.19.5.",
-    "version": "1.1.0"
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.20.1) v0.21.0~develop.",
+    "version": "1.2.0~develop"
   },
   "paths": {
     "/info": {
@@ -1300,6 +1300,428 @@
         }
       }
     },
+    "/files": {
+      "get": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Get Files",
+        "operationId": "get_files_files_get",
+        "parameters": [
+          {
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+            "required": false,
+            "schema": {
+              "title": "Filter",
+              "type": "string",
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+              "default": ""
+            },
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "required": false,
+            "schema": {
+              "title": "Response Format",
+              "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+              "default": "json"
+            },
+            "name": "response_format",
+            "in": "query"
+          },
+          {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "required": false,
+            "schema": {
+              "title": "Email Address",
+              "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+              "format": "email",
+              "default": ""
+            },
+            "name": "email_address",
+            "in": "query"
+          },
+          {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+            "required": false,
+            "schema": {
+              "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+              "default": ""
+            },
+            "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+            "required": false,
+            "schema": {
+              "title": "Sort",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+              "default": ""
+            },
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+            "required": false,
+            "schema": {
+              "title": "Page Limit",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+              "default": 20
+            },
+            "name": "page_limit",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+            "required": false,
+            "schema": {
+              "title": "Page Offset",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+              "default": 0
+            },
+            "name": "page_offset",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+            "required": false,
+            "schema": {
+              "title": "Page Number",
+              "type": "integer",
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+            },
+            "name": "page_number",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+            "required": false,
+            "schema": {
+              "title": "Page Cursor",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+              "default": 0
+            },
+            "name": "page_cursor",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+            "required": false,
+            "schema": {
+              "title": "Page Above",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+              "default": 0
+            },
+            "name": "page_above",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+            "required": false,
+            "schema": {
+              "title": "Page Below",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+              "default": 0
+            },
+            "name": "page_below",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
+            "in": "query"
+          },
+          {
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "required": false,
+            "schema": {
+              "title": "Api Hint",
+              "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
+              "type": "string",
+              "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+              "default": ""
+            },
+            "name": "api_hint",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileResponseMany"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/files/{entry_id}": {
+      "get": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Get Single File",
+        "operationId": "get_single_file_files__entry_id__get",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "title": "Entry Id",
+              "type": "string"
+            },
+            "name": "entry_id",
+            "in": "path"
+          },
+          {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "required": false,
+            "schema": {
+              "title": "Response Format",
+              "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+              "default": "json"
+            },
+            "name": "response_format",
+            "in": "query"
+          },
+          {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "required": false,
+            "schema": {
+              "title": "Email Address",
+              "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+              "format": "email",
+              "default": ""
+            },
+            "name": "email_address",
+            "in": "query"
+          },
+          {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+            "required": false,
+            "schema": {
+              "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+              "default": ""
+            },
+            "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
+            "in": "query"
+          },
+          {
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "required": false,
+            "schema": {
+              "title": "Api Hint",
+              "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
+              "type": "string",
+              "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+              "default": ""
+            },
+            "name": "api_hint",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileResponseOne"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/versions": {
       "get": {
         "tags": [
@@ -1334,6 +1756,18 @@
           "no"
         ],
         "description": "Enumeration of aggregate values"
+      },
+      "AllowedJSONSchemaDataType": {
+        "title": "AllowedJSONSchemaDataType",
+        "enum": [
+          "boolean",
+          "object",
+          "array",
+          "number",
+          "string",
+          "integer"
+        ],
+        "description": "The allowed values for `type` in the Property Definition restricted JSON Schema syntax."
       },
       "Assembly": {
         "title": "Assembly",
@@ -1412,7 +1846,9 @@
           "api_version",
           "available_api_versions",
           "available_endpoints",
-          "entry_types_by_format"
+          "entry_types_by_format",
+          "license",
+          "available_licenses"
         ],
         "type": "object",
         "properties": {
@@ -1464,6 +1900,29 @@
               }
             },
             "description": "Available entry endpoints as a function of output formats."
+          },
+          "license": {
+            "title": "License",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Link"
+              },
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) giving a URL to a web page containing a human-readable text describing the license (or licensing options if there are multiple) covering all the data and metadata provided by this database.\nClients are advised not to try automated parsing of this link or its content, but rather rely on the field `available_licenses` instead."
+          },
+          "available_licenses": {
+            "title": "Available Licenses",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of [SPDX license identifiers](https://spdx.org/licenses/) specifying a set of alternative licenses under which the client is granted access to all the data and metadata in this database.\n\nIf the data and metadata is available under multiple alternative licenses, identifiers of these multiple licenses SHOULD be provided to let clients know under which conditions the data and metadata can be used.\nInclusion of a license identifier in the list is a commitment of the database that the rights are in place to grant clients access to all the data and metadata according to the terms of either of these licenses (at the choice of the client).\nIf the licensing information provided via the field `license` omits licensing options specified in `available_licenses`, or if it otherwise contradicts them, a client MUST still be allowed to interpret the inclusion of a license in `available_licenses` as a full commitment from the database that the data and metadata is available, without exceptions, under the respective licenses.\nIf the database cannot make that commitment, e.g., if only part of the data is available under a license, the corresponding license identifier MUST NOT appear in `available_licenses` (but, rather, the field `license` is to be used to clarify the licensing situation.)\nAn empty list indicates that none of the SPDX licenses apply for the entirety of the database and that the licensing situation is clarified in human readable form in the field `license`."
           },
           "is_index": {
             "title": "Is Index",
@@ -1573,50 +2032,640 @@
         },
         "description": "Minimum requirements to represent a relationship resource"
       },
-      "DataType": {
-        "title": "DataType",
-        "enum": [
-          "string",
-          "integer",
-          "float",
-          "boolean",
-          "timestamp",
-          "list",
-          "dictionary",
-          "unknown"
-        ],
-        "description": "Optimade Data Types\n\n    See the section \"Data types\" in the OPTIMADE API specification for more information.\n    "
-      },
       "EntryInfoProperty": {
         "title": "EntryInfoProperty",
         "required": [
-          "description"
+          "title",
+          "description",
+          "x-optimade-property",
+          "x-optimade-implementation",
+          "x-optimade-requirements",
+          "deprecated",
+          "enum",
+          "examples"
         ],
         "type": "object",
         "properties": {
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short single-line human-readable explanation of the defined property appropriate to show as part of a user interface."
+          },
           "description": {
             "title": "Description",
             "type": "string",
-            "description": "A human-readable description of the entry property"
+            "description": "A human-readable multi-line description that explains the purpose, requirements, and conventions of the defined property.\n\nThe format SHOULD be a one-line description, followed by a new paragraph (two newlines), followed by a more detailed description of all the requirements and conventions of the defined property.\nFormatting in the text SHOULD use Markdown in the CommonMark v0.3 format."
           },
-          "unit": {
-            "title": "Unit",
+          "x-optimade-property": {
+            "title": "X-Optimade-Property",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimadePropertyDefinition"
+              }
+            ],
+            "description": "Additional information to define the property that is not covered by fields in the JSON Schema standard."
+          },
+          "x-optimade-unit": {
+            "title": "X-Optimade-Unit",
             "type": "string",
-            "description": "The physical unit of the entry property.\nThis MUST be a valid representation of units according to version 2.1 of [The Unified Code for Units of Measure](https://unitsofmeasure.org/ucum.html).\nIt is RECOMMENDED that non-standard (non-SI) units are described in the description for the property."
+            "description": "A (compound) symbol for the physical unit in which the value of the defined property is given or one of the strings `dimensionless` or `inapplicable`."
           },
-          "sortable": {
-            "title": "Sortable",
-            "type": "boolean",
-            "description": "Defines whether the entry property can be used for sorting with the \"sort\" parameter.\nIf the entry listing endpoint supports sorting, this key MUST be present for sortable properties with value `true`."
+          "x-optimade-implementation": {
+            "title": "X-Optimade-Implementation",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyImplementationInfo"
+              }
+            ],
+            "description": "A dictionary describing the level of OPTIMADE API functionality provided by the present implementation.\nIf an implementation omits this field in its response, a client interacting with that implementation SHOULD NOT make any assumptions about the availability of these features."
+          },
+          "x-optimade-requirements": {
+            "title": "X-Optimade-Requirements",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyRequirementsInfo"
+              }
+            ],
+            "description": "A dictionary describing the level of OPTIMADE API functionality required by all implementations of this property.\nOmitting this field means the corresponding functionality is OPTIONAL."
           },
           "type": {
             "title": "Type",
-            "allOf": [
+            "anyOf": [
               {
-                "$ref": "#/components/schemas/DataType"
+                "$ref": "#/components/schemas/AllowedJSONSchemaDataType"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedJSONSchemaDataType"
+                }
               }
             ],
-            "description": "The type of the property's value.\nThis MUST be any of the types defined in the Data types section.\nFor the purpose of compatibility with future versions of this specification, a client MUST accept values that are not `string` values specifying any of the OPTIMADE Data types, but MUST then also disregard the `type` field.\nNote, if the value is a nested type, only the outermost type should be reported.\nE.g., for the entry resource `structures`, the `species` property is defined as a list of dictionaries, hence its `type` value would be `list`."
+            "description": "A string or list that specifies the type of the defined property.\nIt MUST be one of:\n\n- One of the strings `\"boolean\"`, `\"object\"` (refers to an OPTIMADE dictionary), `\"array\"` (refers to an OPTIMADE list), `\"number\"` (refers to an OPTIMADE float), `\"string\"`, or `\"integer\"`.\n- A list where the first item MUST be one of the strings above, and the second item MUST be the string `\"null\"`."
+          },
+          "deprecated": {
+            "title": "Deprecated",
+            "type": "boolean",
+            "description": " If `TRUE`, implementations SHOULD not use the defined property, and it MAY be removed in the future.\nIf `FALSE`, the defined property is not deprecated.\nThe field not being present means `FALSE`."
+          },
+          "enum": {
+            "title": "Enum",
+            "type": "array",
+            "items": {},
+            "description": "The defined property MUST take one of the values given in the provided list.\nThe items in the list MUST all be of a data type that matches the `type` field and otherwise adhere to the rest of the Property Description.\nIf this key is given, for `null` to be a valid value of the defined property, the list MUST contain a `null` value and the `type` MUST be a list where the second value is the string `\"null\"`."
+          },
+          "examples": {
+            "title": "Examples",
+            "type": "array",
+            "items": {},
+            "description": "A list of example values that the defined property can have.\nThese examples MUST all be of a data type that matches the `type` field and otherwise adhere to the rest of the Property Description."
+          }
+        }
+      },
+      "EntryInfoPropertyArray": {
+        "title": "EntryInfoPropertyArray",
+        "required": [
+          "items",
+          "title",
+          "description",
+          "x-optimade-property",
+          "x-optimade-implementation",
+          "x-optimade-requirements",
+          "deprecated",
+          "enum",
+          "examples"
+        ],
+        "type": "object",
+        "properties": {
+          "items": {
+            "$ref": "#/components/schemas/EntryInfoProperty"
+          },
+          "maxItems": {
+            "title": "Maxitems",
+            "type": "integer"
+          },
+          "minItems": {
+            "title": "Minitems",
+            "type": "integer"
+          },
+          "uniqueItems": {
+            "title": "Uniqueitems",
+            "type": "boolean"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short single-line human-readable explanation of the defined property appropriate to show as part of a user interface."
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "A human-readable multi-line description that explains the purpose, requirements, and conventions of the defined property.\n\nThe format SHOULD be a one-line description, followed by a new paragraph (two newlines), followed by a more detailed description of all the requirements and conventions of the defined property.\nFormatting in the text SHOULD use Markdown in the CommonMark v0.3 format."
+          },
+          "x-optimade-property": {
+            "title": "X-Optimade-Property",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimadePropertyDefinition"
+              }
+            ],
+            "description": "Additional information to define the property that is not covered by fields in the JSON Schema standard."
+          },
+          "x-optimade-unit": {
+            "title": "X-Optimade-Unit",
+            "type": "string",
+            "description": "A (compound) symbol for the physical unit in which the value of the defined property is given or one of the strings `dimensionless` or `inapplicable`."
+          },
+          "x-optimade-implementation": {
+            "title": "X-Optimade-Implementation",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyImplementationInfo"
+              }
+            ],
+            "description": "A dictionary describing the level of OPTIMADE API functionality provided by the present implementation.\nIf an implementation omits this field in its response, a client interacting with that implementation SHOULD NOT make any assumptions about the availability of these features."
+          },
+          "x-optimade-requirements": {
+            "title": "X-Optimade-Requirements",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyRequirementsInfo"
+              }
+            ],
+            "description": "A dictionary describing the level of OPTIMADE API functionality required by all implementations of this property.\nOmitting this field means the corresponding functionality is OPTIONAL."
+          },
+          "type": {
+            "title": "Type",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AllowedJSONSchemaDataType"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedJSONSchemaDataType"
+                }
+              }
+            ],
+            "description": "A string or list that specifies the type of the defined property.\nIt MUST be one of:\n\n- One of the strings `\"boolean\"`, `\"object\"` (refers to an OPTIMADE dictionary), `\"array\"` (refers to an OPTIMADE list), `\"number\"` (refers to an OPTIMADE float), `\"string\"`, or `\"integer\"`.\n- A list where the first item MUST be one of the strings above, and the second item MUST be the string `\"null\"`."
+          },
+          "deprecated": {
+            "title": "Deprecated",
+            "type": "boolean",
+            "description": " If `TRUE`, implementations SHOULD not use the defined property, and it MAY be removed in the future.\nIf `FALSE`, the defined property is not deprecated.\nThe field not being present means `FALSE`."
+          },
+          "enum": {
+            "title": "Enum",
+            "type": "array",
+            "items": {},
+            "description": "The defined property MUST take one of the values given in the provided list.\nThe items in the list MUST all be of a data type that matches the `type` field and otherwise adhere to the rest of the Property Description.\nIf this key is given, for `null` to be a valid value of the defined property, the list MUST contain a `null` value and the `type` MUST be a list where the second value is the string `\"null\"`."
+          },
+          "examples": {
+            "title": "Examples",
+            "type": "array",
+            "items": {},
+            "description": "A list of example values that the defined property can have.\nThese examples MUST all be of a data type that matches the `type` field and otherwise adhere to the rest of the Property Description."
+          }
+        }
+      },
+      "EntryInfoPropertyInteger": {
+        "title": "EntryInfoPropertyInteger",
+        "required": [
+          "title",
+          "description",
+          "x-optimade-property",
+          "x-optimade-implementation",
+          "x-optimade-requirements",
+          "deprecated",
+          "enum",
+          "examples"
+        ],
+        "type": "object",
+        "properties": {
+          "multipleOf": {
+            "title": "Multipleof",
+            "type": "integer"
+          },
+          "maximum": {
+            "title": "Maximum",
+            "type": "integer"
+          },
+          "exclusiveMaximum": {
+            "title": "Exclusivemaximum",
+            "type": "integer"
+          },
+          "minimum": {
+            "title": "Minimum",
+            "type": "integer"
+          },
+          "exclusiveMinimum": {
+            "title": "Exclusiveminimum",
+            "type": "integer"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short single-line human-readable explanation of the defined property appropriate to show as part of a user interface."
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "A human-readable multi-line description that explains the purpose, requirements, and conventions of the defined property.\n\nThe format SHOULD be a one-line description, followed by a new paragraph (two newlines), followed by a more detailed description of all the requirements and conventions of the defined property.\nFormatting in the text SHOULD use Markdown in the CommonMark v0.3 format."
+          },
+          "x-optimade-property": {
+            "title": "X-Optimade-Property",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimadePropertyDefinition"
+              }
+            ],
+            "description": "Additional information to define the property that is not covered by fields in the JSON Schema standard."
+          },
+          "x-optimade-unit": {
+            "title": "X-Optimade-Unit",
+            "type": "string",
+            "description": "A (compound) symbol for the physical unit in which the value of the defined property is given or one of the strings `dimensionless` or `inapplicable`."
+          },
+          "x-optimade-implementation": {
+            "title": "X-Optimade-Implementation",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyImplementationInfo"
+              }
+            ],
+            "description": "A dictionary describing the level of OPTIMADE API functionality provided by the present implementation.\nIf an implementation omits this field in its response, a client interacting with that implementation SHOULD NOT make any assumptions about the availability of these features."
+          },
+          "x-optimade-requirements": {
+            "title": "X-Optimade-Requirements",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyRequirementsInfo"
+              }
+            ],
+            "description": "A dictionary describing the level of OPTIMADE API functionality required by all implementations of this property.\nOmitting this field means the corresponding functionality is OPTIONAL."
+          },
+          "type": {
+            "title": "Type",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AllowedJSONSchemaDataType"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedJSONSchemaDataType"
+                }
+              }
+            ],
+            "description": "A string or list that specifies the type of the defined property.\nIt MUST be one of:\n\n- One of the strings `\"boolean\"`, `\"object\"` (refers to an OPTIMADE dictionary), `\"array\"` (refers to an OPTIMADE list), `\"number\"` (refers to an OPTIMADE float), `\"string\"`, or `\"integer\"`.\n- A list where the first item MUST be one of the strings above, and the second item MUST be the string `\"null\"`."
+          },
+          "deprecated": {
+            "title": "Deprecated",
+            "type": "boolean",
+            "description": " If `TRUE`, implementations SHOULD not use the defined property, and it MAY be removed in the future.\nIf `FALSE`, the defined property is not deprecated.\nThe field not being present means `FALSE`."
+          },
+          "enum": {
+            "title": "Enum",
+            "type": "array",
+            "items": {},
+            "description": "The defined property MUST take one of the values given in the provided list.\nThe items in the list MUST all be of a data type that matches the `type` field and otherwise adhere to the rest of the Property Description.\nIf this key is given, for `null` to be a valid value of the defined property, the list MUST contain a `null` value and the `type` MUST be a list where the second value is the string `\"null\"`."
+          },
+          "examples": {
+            "title": "Examples",
+            "type": "array",
+            "items": {},
+            "description": "A list of example values that the defined property can have.\nThese examples MUST all be of a data type that matches the `type` field and otherwise adhere to the rest of the Property Description."
+          }
+        }
+      },
+      "EntryInfoPropertyNumber": {
+        "title": "EntryInfoPropertyNumber",
+        "required": [
+          "title",
+          "description",
+          "x-optimade-property",
+          "x-optimade-implementation",
+          "x-optimade-requirements",
+          "deprecated",
+          "enum",
+          "examples"
+        ],
+        "type": "object",
+        "properties": {
+          "multipleOf": {
+            "title": "Multipleof",
+            "type": "integer"
+          },
+          "maximum": {
+            "title": "Maximum",
+            "type": "integer"
+          },
+          "exclusiveMaximum": {
+            "title": "Exclusivemaximum",
+            "type": "integer"
+          },
+          "minimum": {
+            "title": "Minimum",
+            "type": "integer"
+          },
+          "exclusiveMinimum": {
+            "title": "Exclusiveminimum",
+            "type": "integer"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short single-line human-readable explanation of the defined property appropriate to show as part of a user interface."
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "A human-readable multi-line description that explains the purpose, requirements, and conventions of the defined property.\n\nThe format SHOULD be a one-line description, followed by a new paragraph (two newlines), followed by a more detailed description of all the requirements and conventions of the defined property.\nFormatting in the text SHOULD use Markdown in the CommonMark v0.3 format."
+          },
+          "x-optimade-property": {
+            "title": "X-Optimade-Property",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimadePropertyDefinition"
+              }
+            ],
+            "description": "Additional information to define the property that is not covered by fields in the JSON Schema standard."
+          },
+          "x-optimade-unit": {
+            "title": "X-Optimade-Unit",
+            "type": "string",
+            "description": "A (compound) symbol for the physical unit in which the value of the defined property is given or one of the strings `dimensionless` or `inapplicable`."
+          },
+          "x-optimade-implementation": {
+            "title": "X-Optimade-Implementation",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyImplementationInfo"
+              }
+            ],
+            "description": "A dictionary describing the level of OPTIMADE API functionality provided by the present implementation.\nIf an implementation omits this field in its response, a client interacting with that implementation SHOULD NOT make any assumptions about the availability of these features."
+          },
+          "x-optimade-requirements": {
+            "title": "X-Optimade-Requirements",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyRequirementsInfo"
+              }
+            ],
+            "description": "A dictionary describing the level of OPTIMADE API functionality required by all implementations of this property.\nOmitting this field means the corresponding functionality is OPTIONAL."
+          },
+          "type": {
+            "title": "Type",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AllowedJSONSchemaDataType"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedJSONSchemaDataType"
+                }
+              }
+            ],
+            "description": "A string or list that specifies the type of the defined property.\nIt MUST be one of:\n\n- One of the strings `\"boolean\"`, `\"object\"` (refers to an OPTIMADE dictionary), `\"array\"` (refers to an OPTIMADE list), `\"number\"` (refers to an OPTIMADE float), `\"string\"`, or `\"integer\"`.\n- A list where the first item MUST be one of the strings above, and the second item MUST be the string `\"null\"`."
+          },
+          "deprecated": {
+            "title": "Deprecated",
+            "type": "boolean",
+            "description": " If `TRUE`, implementations SHOULD not use the defined property, and it MAY be removed in the future.\nIf `FALSE`, the defined property is not deprecated.\nThe field not being present means `FALSE`."
+          },
+          "enum": {
+            "title": "Enum",
+            "type": "array",
+            "items": {},
+            "description": "The defined property MUST take one of the values given in the provided list.\nThe items in the list MUST all be of a data type that matches the `type` field and otherwise adhere to the rest of the Property Description.\nIf this key is given, for `null` to be a valid value of the defined property, the list MUST contain a `null` value and the `type` MUST be a list where the second value is the string `\"null\"`."
+          },
+          "examples": {
+            "title": "Examples",
+            "type": "array",
+            "items": {},
+            "description": "A list of example values that the defined property can have.\nThese examples MUST all be of a data type that matches the `type` field and otherwise adhere to the rest of the Property Description."
+          }
+        }
+      },
+      "EntryInfoPropertyObject": {
+        "title": "EntryInfoPropertyObject",
+        "required": [
+          "properties",
+          "required",
+          "title",
+          "description",
+          "x-optimade-property",
+          "x-optimade-implementation",
+          "x-optimade-requirements",
+          "deprecated",
+          "enum",
+          "examples"
+        ],
+        "type": "object",
+        "properties": {
+          "properties": {
+            "title": "Properties",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/EntryInfoProperty"
+            },
+            "description": "Gives key-value pairs where each value is an inner Property Definition.\nThe defined property is a dictionary that can only contain keys present in this dictionary, and, if so, the corresponding value is described by the respective inner Property Definition.\n(Or, if the `type` field is the list \"object\" and \"null\", it can also be `null`.)"
+          },
+          "required": {
+            "title": "Required",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The list MUST only contain strings.\n\nThe defined property MUST have keys that match all the strings in this list.\nOther keys present in the `properties` field are OPTIONAL in the defined property.\nIf not present or empty, all keys in `properties` are regarded as OPTIONAL."
+          },
+          "maxProperties": {
+            "title": "Maxproperties",
+            "type": "integer"
+          },
+          "minProperties": {
+            "title": "Minproperties",
+            "type": "integer"
+          },
+          "dependentRequired": {
+            "title": "Dependentrequired",
+            "type": "object"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short single-line human-readable explanation of the defined property appropriate to show as part of a user interface."
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "A human-readable multi-line description that explains the purpose, requirements, and conventions of the defined property.\n\nThe format SHOULD be a one-line description, followed by a new paragraph (two newlines), followed by a more detailed description of all the requirements and conventions of the defined property.\nFormatting in the text SHOULD use Markdown in the CommonMark v0.3 format."
+          },
+          "x-optimade-property": {
+            "title": "X-Optimade-Property",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimadePropertyDefinition"
+              }
+            ],
+            "description": "Additional information to define the property that is not covered by fields in the JSON Schema standard."
+          },
+          "x-optimade-unit": {
+            "title": "X-Optimade-Unit",
+            "type": "string",
+            "description": "A (compound) symbol for the physical unit in which the value of the defined property is given or one of the strings `dimensionless` or `inapplicable`."
+          },
+          "x-optimade-implementation": {
+            "title": "X-Optimade-Implementation",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyImplementationInfo"
+              }
+            ],
+            "description": "A dictionary describing the level of OPTIMADE API functionality provided by the present implementation.\nIf an implementation omits this field in its response, a client interacting with that implementation SHOULD NOT make any assumptions about the availability of these features."
+          },
+          "x-optimade-requirements": {
+            "title": "X-Optimade-Requirements",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyRequirementsInfo"
+              }
+            ],
+            "description": "A dictionary describing the level of OPTIMADE API functionality required by all implementations of this property.\nOmitting this field means the corresponding functionality is OPTIONAL."
+          },
+          "type": {
+            "title": "Type",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AllowedJSONSchemaDataType"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedJSONSchemaDataType"
+                }
+              }
+            ],
+            "description": "A string or list that specifies the type of the defined property.\nIt MUST be one of:\n\n- One of the strings `\"boolean\"`, `\"object\"` (refers to an OPTIMADE dictionary), `\"array\"` (refers to an OPTIMADE list), `\"number\"` (refers to an OPTIMADE float), `\"string\"`, or `\"integer\"`.\n- A list where the first item MUST be one of the strings above, and the second item MUST be the string `\"null\"`."
+          },
+          "deprecated": {
+            "title": "Deprecated",
+            "type": "boolean",
+            "description": " If `TRUE`, implementations SHOULD not use the defined property, and it MAY be removed in the future.\nIf `FALSE`, the defined property is not deprecated.\nThe field not being present means `FALSE`."
+          },
+          "enum": {
+            "title": "Enum",
+            "type": "array",
+            "items": {},
+            "description": "The defined property MUST take one of the values given in the provided list.\nThe items in the list MUST all be of a data type that matches the `type` field and otherwise adhere to the rest of the Property Description.\nIf this key is given, for `null` to be a valid value of the defined property, the list MUST contain a `null` value and the `type` MUST be a list where the second value is the string `\"null\"`."
+          },
+          "examples": {
+            "title": "Examples",
+            "type": "array",
+            "items": {},
+            "description": "A list of example values that the defined property can have.\nThese examples MUST all be of a data type that matches the `type` field and otherwise adhere to the rest of the Property Description."
+          }
+        }
+      },
+      "EntryInfoPropertyString": {
+        "title": "EntryInfoPropertyString",
+        "required": [
+          "title",
+          "description",
+          "x-optimade-property",
+          "x-optimade-implementation",
+          "x-optimade-requirements",
+          "deprecated",
+          "enum",
+          "examples"
+        ],
+        "type": "object",
+        "properties": {
+          "maxLength": {
+            "title": "Maxlength",
+            "type": "integer"
+          },
+          "minLength": {
+            "title": "Minlength",
+            "type": "integer"
+          },
+          "format": {
+            "$ref": "#/components/schemas/JSONSchemaStringFormat"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short single-line human-readable explanation of the defined property appropriate to show as part of a user interface."
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "A human-readable multi-line description that explains the purpose, requirements, and conventions of the defined property.\n\nThe format SHOULD be a one-line description, followed by a new paragraph (two newlines), followed by a more detailed description of all the requirements and conventions of the defined property.\nFormatting in the text SHOULD use Markdown in the CommonMark v0.3 format."
+          },
+          "x-optimade-property": {
+            "title": "X-Optimade-Property",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OptimadePropertyDefinition"
+              }
+            ],
+            "description": "Additional information to define the property that is not covered by fields in the JSON Schema standard."
+          },
+          "x-optimade-unit": {
+            "title": "X-Optimade-Unit",
+            "type": "string",
+            "description": "A (compound) symbol for the physical unit in which the value of the defined property is given or one of the strings `dimensionless` or `inapplicable`."
+          },
+          "x-optimade-implementation": {
+            "title": "X-Optimade-Implementation",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyImplementationInfo"
+              }
+            ],
+            "description": "A dictionary describing the level of OPTIMADE API functionality provided by the present implementation.\nIf an implementation omits this field in its response, a client interacting with that implementation SHOULD NOT make any assumptions about the availability of these features."
+          },
+          "x-optimade-requirements": {
+            "title": "X-Optimade-Requirements",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PropertyRequirementsInfo"
+              }
+            ],
+            "description": "A dictionary describing the level of OPTIMADE API functionality required by all implementations of this property.\nOmitting this field means the corresponding functionality is OPTIONAL."
+          },
+          "type": {
+            "title": "Type",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AllowedJSONSchemaDataType"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedJSONSchemaDataType"
+                }
+              }
+            ],
+            "description": "A string or list that specifies the type of the defined property.\nIt MUST be one of:\n\n- One of the strings `\"boolean\"`, `\"object\"` (refers to an OPTIMADE dictionary), `\"array\"` (refers to an OPTIMADE list), `\"number\"` (refers to an OPTIMADE float), `\"string\"`, or `\"integer\"`.\n- A list where the first item MUST be one of the strings above, and the second item MUST be the string `\"null\"`."
+          },
+          "deprecated": {
+            "title": "Deprecated",
+            "type": "boolean",
+            "description": " If `TRUE`, implementations SHOULD not use the defined property, and it MAY be removed in the future.\nIf `FALSE`, the defined property is not deprecated.\nThe field not being present means `FALSE`."
+          },
+          "enum": {
+            "title": "Enum",
+            "type": "array",
+            "items": {},
+            "description": "The defined property MUST take one of the values given in the provided list.\nThe items in the list MUST all be of a data type that matches the `type` field and otherwise adhere to the rest of the Property Description.\nIf this key is given, for `null` to be a valid value of the defined property, the list MUST contain a `null` value and the `type` MUST be a list where the second value is the string `\"null\"`."
+          },
+          "examples": {
+            "title": "Examples",
+            "type": "array",
+            "items": {},
+            "description": "A list of example values that the defined property can have.\nThese examples MUST all be of a data type that matches the `type` field and otherwise adhere to the rest of the Property Description."
           }
         }
       },
@@ -1647,7 +2696,26 @@
             "title": "Properties",
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/components/schemas/EntryInfoProperty"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/EntryInfoProperty"
+                },
+                {
+                  "$ref": "#/components/schemas/EntryInfoPropertyArray"
+                },
+                {
+                  "$ref": "#/components/schemas/EntryInfoPropertyInteger"
+                },
+                {
+                  "$ref": "#/components/schemas/EntryInfoPropertyNumber"
+                },
+                {
+                  "$ref": "#/components/schemas/EntryInfoPropertyObject"
+                },
+                {
+                  "$ref": "#/components/schemas/EntryInfoPropertyString"
+                }
+              ]
             },
             "description": "A dictionary describing queryable properties for this entry type, where each key is a property name."
           },
@@ -2011,6 +3079,354 @@
         },
         "description": "an object containing references to the source of the error"
       },
+      "FileResource": {
+        "title": "FileResource",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          },
+          "type": {
+            "title": "Type",
+            "pattern": "^files$",
+            "type": "string",
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Examples**:\n    - `\"structures\"`",
+            "default": "files",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/FileResourceAttributes"
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryRelationships"
+              }
+            ],
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
+          }
+        },
+        "description": "Representing a structure."
+      },
+      "FileResourceAttributes": {
+        "title": "FileResourceAttributes",
+        "required": [
+          "last_modified",
+          "url",
+          "url_stable_until",
+          "name",
+          "size",
+          "media_type",
+          "modification_timestamp",
+          "description",
+          "checksums",
+          "atime",
+          "ctime",
+          "mtime"
+        ],
+        "type": "object",
+        "properties": {
+          "immutable_id": {
+            "title": "Immutable Id",
+            "type": "string",
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
+          },
+          "last_modified": {
+            "title": "Last Modified",
+            "type": "string",
+            "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
+            "format": "date-time",
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string",
+            "description": "The URL to get the contents of a file.\n- **Type**: string\n- **Requirements/Conventions**:\n\n  - **Support**: MUST be supported by all implementations, MUST NOT be :val:`null`.\n  - **Query**: Support for queries on this property is OPTIONAL.\n  - **Response**: REQUIRED in the response.\n  - The URL MUST point to the actual contents of a file (i.e. byte stream), not an intermediate (preview) representation.\n    For example, if referring to a file on GitHub, a link should point to raw contents.\n\n- **Examples**:\n\n  - :val:`\"https://example.org/files/cifs/1000000.cif\"`\n",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
+          },
+          "url_stable_until": {
+            "title": "Url Stable Until",
+            "type": "string",
+            "description": "Point in time until which the URL in `url` is guaranteed to stay stable.\n- **Type**: timestamp\n- **Requirements/Conventions**:\n\n  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.\n  - **Query**: Support for queries on this property is OPTIONAL.\n  - :val:`null` means that there is no stability guarantee for the URL in `url`.\n    Indefinite support could be communicated by providing a date sufficiently far in the future, for example, :val:`9999-12-31`.",
+            "format": "date-time",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "Base name of a file.\n- **Type**: string\n- **Requirements/Conventions**:\n\n  - **Support**: MUST be supported by all implementations, MUST NOT be :val:`null`.\n  - **Query**: Support for queries on this property is OPTIONAL.\n  - File name extension is an integral part of a file name and, if available, MUST be included.\n\n- **Examples**:\n\n  - :val:`\"1000000.cif\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "optional"
+          },
+          "size": {
+            "title": "Size",
+            "type": "integer",
+            "description": "Size of a file in bytes.\n- **Type**: integer\n- **Requirements/Conventions**:\n\n  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.\n  - **Query**: Support for queries on this property is OPTIONAL.\n  - If provided, it MUST be guaranteed that either exact size of a file is given or its upper bound.\n    This way if a client reserves a static buffer or truncates the download stream after this many bytes the whole file would be received.\n    Such provision is included to allow the providers to serve on-the-fly compressed files.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "media_type": {
+            "title": "Media Type",
+            "type": "string",
+            "description": "Media type identifier (also known as MIME type), for a file as per `RFC 6838 Media Type Specifications and Registration Procedures <https://datatracker.ietf.org/doc/html/rfc6838>`__.\n- **Type**: string\n- **Requirements/Conventions**:\n\n  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.\n  - **Query**: Support for queries on this property is OPTIONAL.\n\n- **Examples**:\n\n  - :val:`\"chemical/x-cif\"`",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string",
+            "description": "Version information of a file (e.g. commit, revision, timestamp).\n- **Type**: string\n- **Requirements/Conventions**:\n\n  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.\n  - **Query**: Support for queries on this property is OPTIONAL.\n  - If provided, it MUST be guaranteed that file contents pertaining to the same combination of :field:`id` and :field:`version` are the same",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "modification_timestamp": {
+            "title": "Modification Timestamp",
+            "type": "string",
+            "description": "Timestamp of the last modification of file contents.\n  A modification is understood as an addition, change or deletion of one or more bytes, resulting in file contents different from the previous.\n- **Type**: timestamp\n- **Requirements/Conventions**:\n\n  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.\n  - **Query**: Support for queries on this property is OPTIONAL.\n  - Timestamps of subsequent file modifications SHOULD be increasing (not earlier than previous timestamps).",
+            "format": "date-time",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "Free-form description of a file.\n- **Type**: string\n- **Requirements/Conventions**:\n\n  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.\n  - **Query**: Support for queries on this property is OPTIONAL.\n\n- **Examples**:\n\n  - :val:`\"POSCAR format file\"`",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "checksums": {
+            "title": "Checksums",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Dictionary providing checksums of file contents.\n* **Type**: dictionary with keys identifying checksum functions and values (strings) giving the actual checksums\n* **Requirements/Conventions**:\n\n  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.\n  - **Query**: Support for queries on this property is OPTIONAL.\n  - Supported dictionary keys: :property:`md5`, :property:`sha1`, :property:`sha224`, :property:`sha256`, :property:`sha384`, :property:`sha512`.\n    Checksums outside this list MAY be used, but their names MUST be prefixed by database-provider-specific namespace prefix (see appendix `Database-Provider-Specific Namespace Prefixes`_).\n",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "atime": {
+            "title": "Atime",
+            "type": "string",
+            "description": "Time of last access of a file as per POSIX standard.\n- **Type**: timestamp\n- **Requirements/Conventions**:\n\n  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.\n  - **Query**: Support for queries on this property is OPTIONAL.",
+            "format": "date-time",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "ctime": {
+            "title": "Ctime",
+            "type": "string",
+            "description": "Time of last status change of a file as per POSIX standard.\n- **Type**: timestamp\n- **Requirements/Conventions**:\n\n  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.\n  - **Query**: Support for queries on this property is OPTIONAL.",
+            "format": "date-time",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional",
+            "x-optimade-unit": "\u00c5"
+          },
+          "mtime": {
+            "title": "Mtime",
+            "type": "string",
+            "description": " Time of last modification of a file as per POSIX standard.\n- **Type**: timestamp\n- **Requirements/Conventions**:\n\n  - **Support**: OPTIONAL support in implementations, i.e., MAY be :val:`null`.\n  - **Query**: Support for queries on this property is OPTIONAL.\n  - It should be noted that the values of :field:`last_modified`, :field:`modification_timestamp` and :field:`mtime` do not necessary match.\n    :field:`last_modified` pertains to the modification of the OPTIMADE metadata, :field:`modification_timestamp` pertains to file contents and :field:`mtime` pertains to the modification of the file (not necessary changing its contents).\n    For example, appending an empty string to a file would result in the change of :field:`mtime` in some operating systems, but this would not be deemed as a modification of its contents.\n",
+            "format": "date-time",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          }
+        },
+        "description": "This class contains the Field for the attributes used to represent a file, e.g. ."
+      },
+      "FileResponseMany": {
+        "title": "FileResponseMany",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FileResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ],
+            "description": "List of unique OPTIMADE files entry resource objects."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "description": "A list of unique errors"
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
+      "FileResponseOne": {
+        "title": "FileResponseOne",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FileResource"
+              },
+              {
+                "type": "object"
+              }
+            ],
+            "description": "A single files entry resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "description": "A list of unique errors"
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
       "Implementation": {
         "title": "Implementation",
         "type": "object",
@@ -2162,6 +3578,18 @@
           }
         },
         "description": "errors are not allowed"
+      },
+      "JSONSchemaStringFormat": {
+        "title": "JSONSchemaStringFormat",
+        "enum": [
+          "date-time",
+          "date",
+          "time",
+          "duration",
+          "email",
+          "uri"
+        ],
+        "description": "An enumeration."
       },
       "JsonApi": {
         "title": "JsonApi",
@@ -2452,6 +3880,15 @@
         "properties": {},
         "description": "Non-standard meta-information that can not be represented as an attribute or relationship."
       },
+      "OptimadeAllowedUnitStandard": {
+        "title": "OptimadeAllowedUnitStandard",
+        "enum": [
+          "gnu units",
+          "ucum",
+          "qudt"
+        ],
+        "description": "An enumeration."
+      },
       "OptimadeError": {
         "title": "OptimadeError",
         "required": [
@@ -2514,6 +3951,101 @@
         },
         "description": "detail MUST be present"
       },
+      "OptimadePropertyDefinition": {
+        "title": "OptimadePropertyDefinition",
+        "required": [
+          "property-uri",
+          "version",
+          "unit-definitions",
+          "resource-uris"
+        ],
+        "type": "object",
+        "properties": {
+          "property-uri": {
+            "title": "Property-Uri",
+            "type": "string",
+            "description": "A static URI identifier that is a URN or URL representing the specific version of the property.\nIt SHOULD NOT be changed as long as the property definition remains the same, and SHOULD be changed when the property definition changes.\n(If it is a URL, clients SHOULD NOT assign any interpretation to the response when resolving that URL.)"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string",
+            "description": "This string indicates the version of the property definition.\nThe string SHOULD be in the format described by the [semantic versioning v2](https://semver.org/spec/v2.0.0.html) standard."
+          },
+          "unit-definitions": {
+            "title": "Unit-Definitions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptimadeUnitDefinition"
+            },
+            "description": "A list of definitions of the symbols used in the Property Definition (including its nested levels) for physical units given as values of the `x-optimade-unit` field.\nThis field MUST be included if the defined property, at any level, includes an `x-optimade-unit` with a value that is not `dimensionless` or `inapplicable`."
+          },
+          "resource-uris": {
+            "title": "Resource-Uris",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PropertyRemoteResource"
+            },
+            "description": "A list of dictionaries that references remote resources that describe the property."
+          }
+        }
+      },
+      "OptimadeUnitDefinition": {
+        "title": "OptimadeUnitDefinition",
+        "required": [
+          "symbol",
+          "title",
+          "description",
+          "standard",
+          "resource-uris"
+        ],
+        "type": "object",
+        "properties": {
+          "symbol": {
+            "title": "Symbol",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "standard": {
+            "$ref": "#/components/schemas/OptimadeUnitStandard"
+          },
+          "resource-uris": {
+            "title": "Resource-Uris",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UnitResourceURIs"
+            }
+          }
+        }
+      },
+      "OptimadeUnitStandard": {
+        "title": "OptimadeUnitStandard",
+        "required": [
+          "name",
+          "version",
+          "symbol"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/OptimadeAllowedUnitStandard"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string"
+          },
+          "symbol": {
+            "title": "Symbol",
+            "type": "string"
+          }
+        }
+      },
       "Periodicity": {
         "title": "Periodicity",
         "enum": [
@@ -2553,6 +4085,99 @@
           }
         },
         "description": "A person, i.e., an author, editor or other."
+      },
+      "PropertyImplementationInfo": {
+        "title": "PropertyImplementationInfo",
+        "required": [
+          "sortable",
+          "query-support",
+          "query-support-operators"
+        ],
+        "type": "object",
+        "properties": {
+          "sortable": {
+            "title": "Sortable",
+            "type": "boolean",
+            "description": "If `TRUE`, specifies that results can be sorted on this property.\n    If `FALSE`, specifies that results cannot be sorted on this property.\n    Omitting the field is equivalent to `FALSE`."
+          },
+          "query-support": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/QuerySupport"
+              }
+            ],
+            "description": "Defines a required level of support in formulating queries on this field.\n\n    The string MUST be one of the following:\n\n    - `all mandatory`: the defined property MUST be queryable using the OPTIMADE filter language with support for all mandatory filter features.\n    - `equality only`: the defined property MUST be queryable using the OPTIMADE filter language equality and inequality operators. Other filter language features do not need to be available.\n    - `partial`: the defined property MUST be queryable with support for a subset of the filter language operators as specified by the field `query-support-operators`.\n    - `none`: the defined property does not need to be queryable with any features of the filter language."
+          },
+          "query-support-operators": {
+            "title": "Query-Support-Operators",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Defines the filter language features supported on this property.\n\nEach string in the list MUST be one of `<`, `<=`, `>`, `>=`, `=`, `!=`, `CONTAINS`, `STARTS WITH`, `ENDS WITH`:, `HAS`, `HAS ALL`, `HAS ANY`, `HAS ONLY`, `IS KNOWN`, `IS UNKNOWN` with the following meanings:\n\n- `<`, `<=`, `>`, `>=`, `=`, `!=`: indicating support for filtering this property using the respective operator.\n  If the property is of Boolean type, support for `=` also designates support for boolean comparisons with the property being true that omit \":filter-fragment:`= TRUE`\", e.g., specifying that filtering for \"`is_yellow = TRUE`\" is supported also implies support for \"`is_yellow`\" (which means the same thing).\n  Support for \"`NOT is_yellow`\" also follows.\n\n- `CONTAINS`, `STARTS WITH`, `ENDS WITH`: indicating support for substring filtering of this property using the respective operator. MUST NOT appear if the property is not of type String.\n\n- `HAS`, `HAS ALL`, `HAS ANY`: indicating support of the MANDATORY features for list property comparison using the respective operator. MUST NOT appear if the property is not of type List.\n\n- `HAS ONLY`: indicating support for list property comparison with all or a subset of the OPTIONAL constructs using this operator. MUST NOT appear if the property is not of type List.\n\n- `IS KNOWN`, `IS UNKNOWN`: indicating support for filtering this property on unknown values using the respective operator."
+          }
+        }
+      },
+      "PropertyRemoteResource": {
+        "title": "PropertyRemoteResource",
+        "required": [
+          "relation",
+          "uri"
+        ],
+        "type": "object",
+        "properties": {
+          "relation": {
+            "title": "Relation",
+            "type": "string",
+            "description": "A human-readable description of the relationship between the property and the remote resource, e.g., a 'natural language description'."
+          },
+          "uri": {
+            "title": "Uri",
+            "type": "string",
+            "description": "A URI of the external resource (which MAY be a resolvable URL)."
+          }
+        }
+      },
+      "PropertyRequirementsInfo": {
+        "title": "PropertyRequirementsInfo",
+        "required": [
+          "sortable",
+          "query-support",
+          "query-support-operators",
+          "support"
+        ],
+        "type": "object",
+        "properties": {
+          "sortable": {
+            "title": "Sortable",
+            "type": "boolean",
+            "description": "If `TRUE`, specifies that results can be sorted on this property.\n    If `FALSE`, specifies that results cannot be sorted on this property.\n    Omitting the field is equivalent to `FALSE`."
+          },
+          "query-support": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/QuerySupport"
+              }
+            ],
+            "description": "Defines a required level of support in formulating queries on this field.\n\n    The string MUST be one of the following:\n\n    - `all mandatory`: the defined property MUST be queryable using the OPTIMADE filter language with support for all mandatory filter features.\n    - `equality only`: the defined property MUST be queryable using the OPTIMADE filter language equality and inequality operators. Other filter language features do not need to be available.\n    - `partial`: the defined property MUST be queryable with support for a subset of the filter language operators as specified by the field `query-support-operators`.\n    - `none`: the defined property does not need to be queryable with any features of the filter language."
+          },
+          "query-support-operators": {
+            "title": "Query-Support-Operators",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Defines the filter language features supported on this property.\n\nEach string in the list MUST be one of `<`, `<=`, `>`, `>=`, `=`, `!=`, `CONTAINS`, `STARTS WITH`, `ENDS WITH`:, `HAS`, `HAS ALL`, `HAS ANY`, `HAS ONLY`, `IS KNOWN`, `IS UNKNOWN` with the following meanings:\n\n- `<`, `<=`, `>`, `>=`, `=`, `!=`: indicating support for filtering this property using the respective operator.\n  If the property is of Boolean type, support for `=` also designates support for boolean comparisons with the property being true that omit \":filter-fragment:`= TRUE`\", e.g., specifying that filtering for \"`is_yellow = TRUE`\" is supported also implies support for \"`is_yellow`\" (which means the same thing).\n  Support for \"`NOT is_yellow`\" also follows.\n\n- `CONTAINS`, `STARTS WITH`, `ENDS WITH`: indicating support for substring filtering of this property using the respective operator. MUST NOT appear if the property is not of type String.\n\n- `HAS`, `HAS ALL`, `HAS ANY`: indicating support of the MANDATORY features for list property comparison using the respective operator. MUST NOT appear if the property is not of type List.\n\n- `HAS ONLY`: indicating support for list property comparison with all or a subset of the OPTIONAL constructs using this operator. MUST NOT appear if the property is not of type List.\n\n- `IS KNOWN`, `IS UNKNOWN`: indicating support for filtering this property on unknown values using the respective operator."
+          },
+          "support": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SupportLevel"
+              }
+            ],
+            "description": "Describes the minimal required level of support for the Property by an implementation.\n\n    This field SHOULD only appear in a `x-optimade-requirements` that is at the outermost level of a Property Definition, as the meaning of its inclusion on other levels is not defined.\n    The string MUST be one of the following:\n\n    - `must`: the defined property MUST be recognized by the implementation (e.g., in filter strings) and MUST NOT be `null`.\n    - `should`: the defined property MUST be recognized by the implementation (e.g., in filter strings) and SHOULD NOT be `null`.\n    - `may`: it is OPTIONAL for the implementation to recognize the defined property and it MAY be equal to `null`."
+          }
+        }
       },
       "Provider": {
         "title": "Provider",
@@ -2596,6 +4221,16 @@
           }
         },
         "description": "Information on the database provider of the implementation."
+      },
+      "QuerySupport": {
+        "title": "QuerySupport",
+        "enum": [
+          "all mandatory",
+          "equality only",
+          "partial",
+          "none"
+        ],
+        "description": "An enumeration."
       },
       "ReferenceRelationship": {
         "title": "ReferenceRelationship",
@@ -3280,6 +4915,12 @@
             "type": "string",
             "description": "response string from the server"
           },
+          "request_delay": {
+            "title": "Request Delay",
+            "minimum": 0.0,
+            "type": "number",
+            "description": "A non-negative float giving time in seconds that the client is suggested to wait before issuing a subsequent request."
+          },
           "implementation": {
             "title": "Implementation",
             "allOf": [
@@ -3359,9 +5000,9 @@
               "type": "number"
             },
             "description": "If present MUST be a list of floats expressed in a.m.u.\nElements denoting vacancies MUST have masses equal to 0.",
-            "x-optimade-unit": "a.m.u.",
             "x-optimade-support": "optional",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-unit": "a.m.u."
           },
           "original_name": {
             "title": "Original Name",
@@ -3639,8 +5280,24 @@
             },
             "description": "The three lattice vectors in Cartesian coordinates, in \u00e5ngstr\u00f6m (\u00c5).\n\n- **Type**: list of list of floats or unknown values.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - MUST be a list of three vectors *a*, *b*, and *c*, where each of the vectors MUST BE a list of the vector's coordinates along the x, y, and z Cartesian coordinates.\n      (Therefore, the first index runs over the three lattice vectors and the second index runs over the x, y, z Cartesian coordinates).\n    - For databases that do not define an absolute Cartesian system (e.g., only defining the length and angles between vectors), the first lattice vector SHOULD be set along *x* and the second on the *xy*-plane.\n    - MUST always contain three vectors of three coordinates each, independently of the elements of property `dimension_types`.\n      The vectors SHOULD by convention be chosen so the determinant of the `lattice_vectors` matrix is different from zero.\n      The vectors in the non-periodic directions have no significance beyond fulfilling these requirements.\n    - The coordinates of the lattice vectors of non-periodic dimensions (i.e., those dimensions for which `dimension_types` is `0`) MAY be given as a list of all `null` values.\n        If a lattice vector contains the value `null`, all coordinates of that lattice vector MUST be `null`.\n\n- **Examples**:\n    - `[[4.0,0.0,0.0],[0.0,4.0,0.0],[0.0,1.0,4.0]]` represents a cell, where the first vector is `(4, 0, 0)`, i.e., a vector aligned along the `x` axis of length 4 \u00c5; the second vector is `(0, 4, 0)`; and the third vector is `(0, 1, 4)`.",
             "nullable": true,
-            "x-optimade-unit": "\u00c5",
             "x-optimade-support": "should",
+            "x-optimade-queryable": "optional",
+            "x-optimade-unit": "\u00c5"
+          },
+          "space_group_hall": {
+            "title": "Space Group Hall",
+            "type": "string",
+            "description": "A Hall space group symbol representing the symmetry of the structure as defined in Hall, S. R. (1981), Acta Cryst. A37, 517-525 and erratum (1981), A37, 921.\n\n- **Type**: string\n\n- **Requirements/Conventions**:\n  - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n  - **Query**: Support for queries on this property is OPTIONAL.\n  - Each component of the Hall symbol MUST be separated by a single space symbol.\n  - If there exists a standard Hall symbol which represents the symmetry it SHOULD be used.\n  - MUST be null if `nperiodic_dimensions` is not equal to 3.",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "optional"
+          },
+          "space_group_it_number": {
+            "title": "Space Group It Number",
+            "maximum": 230.0,
+            "minimum": 1.0,
+            "type": "integer",
+            "description": "Space group number for the structure assigned by the International Tables for Crystallography Vol. A.\n- **Type**: integer\n\n- **Requirements/Conventions**:\n  - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n  - **Query**: Support for queries on this property is OPTIONAL.\n  - The integer value MUST be between 1 and 230.\n  - MUST be null if `nperiodic_dimensions` is not equal to 3.",
+            "x-optimade-support": "optional",
             "x-optimade-queryable": "optional"
           },
           "cartesian_site_positions": {
@@ -3656,9 +5313,9 @@
             },
             "description": "Cartesian positions of each site in the structure.\nA site is usually used to describe positions of atoms; what atoms can be encountered at a given site is conveyed by the `species_at_sites` property, and the species themselves are described in the `species` property.\n\n- **Type**: list of list of floats\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: Support for queries on this property is OPTIONAL.\n      If supported, filters MAY support only a subset of comparison operators.\n    - It MUST be a list of length equal to the number of sites in the structure, where every element is a list of the three Cartesian coordinates of a site expressed as float values in the unit angstrom (\u00c5).\n    - An entry MAY have multiple sites at the same Cartesian position (for a relevant use of this, see e.g., the property `assemblies`).\n\n- **Examples**:\n    - `[[0,0,0],[0,0,2]]` indicates a structure with two sites, one sitting at the origin and one along the (positive) *z*-axis, 2 \u00c5 away from the origin.",
             "nullable": true,
-            "x-optimade-unit": "\u00c5",
             "x-optimade-support": "should",
-            "x-optimade-queryable": "optional"
+            "x-optimade-queryable": "optional",
+            "x-optimade-unit": "\u00c5"
           },
           "nsites": {
             "title": "Nsites",
@@ -3874,6 +5531,15 @@
         },
         "description": "errors are not allowed"
       },
+      "SupportLevel": {
+        "title": "SupportLevel",
+        "enum": [
+          "must",
+          "should",
+          "optional"
+        ],
+        "description": "OPTIMADE property/field support levels"
+      },
       "ToplevelLinks": {
         "title": "ToplevelLinks",
         "type": "object",
@@ -3970,6 +5636,24 @@
           }
         },
         "description": "A set of Links objects, possibly including pagination"
+      },
+      "UnitResourceURIs": {
+        "title": "UnitResourceURIs",
+        "required": [
+          "relation",
+          "uri"
+        ],
+        "type": "object",
+        "properties": {
+          "relation": {
+            "title": "Relation",
+            "type": "string"
+          },
+          "uri": {
+            "title": "Uri",
+            "type": "string"
+          }
+        }
       },
       "Warnings": {
         "title": "Warnings",

--- a/openapi/v1.2.0/optimade_index.json
+++ b/openapi/v1.2.0/optimade_index.json
@@ -1,0 +1,1954 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "OPTIMADE API - Index meta-database",
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.19.5) v0.19.5.",
+    "version": "1.1.0"
+  },
+  "paths": {
+    "/info": {
+      "get": {
+        "tags": [
+          "Info"
+        ],
+        "summary": "Get Info",
+        "operationId": "get_info_info_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexInfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/links": {
+      "get": {
+        "tags": [
+          "Links"
+        ],
+        "summary": "Get Links",
+        "operationId": "get_links_links_get",
+        "parameters": [
+          {
+            "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+            "required": false,
+            "schema": {
+              "title": "Filter",
+              "type": "string",
+              "description": "A filter string, in the format described in section API Filtering Format Specification of the specification.",
+              "default": ""
+            },
+            "name": "filter",
+            "in": "query"
+          },
+          {
+            "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+            "required": false,
+            "schema": {
+              "title": "Response Format",
+              "type": "string",
+              "description": "The output format requested (see section Response Format).\nDefaults to the format string 'json', which specifies the standard output format described in this specification.\nExample: `http://example.com/v1/structures?response_format=xml`",
+              "default": "json"
+            },
+            "name": "response_format",
+            "in": "query"
+          },
+          {
+            "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+            "required": false,
+            "schema": {
+              "title": "Email Address",
+              "type": "string",
+              "description": "An email address of the user making the request.\nThe email SHOULD be that of a person and not an automatic system.\nExample: `http://example.com/v1/structures?email_address=user@example.com`",
+              "format": "email",
+              "default": ""
+            },
+            "name": "email_address",
+            "in": "query"
+          },
+          {
+            "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+            "required": false,
+            "schema": {
+              "title": "Response Fields",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "A comma-delimited set of fields to be provided in the output.\nIf provided, these fields MUST be returned along with the REQUIRED fields.\nOther OPTIONAL fields MUST NOT be returned when this parameter is present.\nExample: `http://example.com/v1/structures?response_fields=last_modified,nsites`",
+              "default": ""
+            },
+            "name": "response_fields",
+            "in": "query"
+          },
+          {
+            "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+            "required": false,
+            "schema": {
+              "title": "Sort",
+              "pattern": "([a-z_][a-z_0-9]*(,[a-z_][a-z_0-9]*)*)?",
+              "type": "string",
+              "description": "If supporting sortable queries, an implementation MUST use the `sort` query parameter with format as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-sorting).\n\nAn implementation MAY support multiple sort fields for a single query.\nIf it does, it again MUST conform to the JSON API 1.0 specification.\n\nIf an implementation supports sorting for an entry listing endpoint, then the `/info/<entries>` endpoint MUST include, for each field name `<fieldname>` in its `data.properties.<fieldname>` response value that can be used for sorting, the key `sortable` with value `true`.\nIf a field name under an entry listing endpoint supporting sorting cannot be used for sorting, the server MUST either leave out the `sortable` key or set it equal to `false` for the specific field name.\nThe set of field names, with `sortable` equal to `true` are allowed to be used in the \"sort fields\" list according to its definition in the JSON API 1.0 specification.\nThe field `sortable` is in addition to each property description and other OPTIONAL fields.\nAn example is shown in the section Entry Listing Info Endpoints.",
+              "default": ""
+            },
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+            "required": false,
+            "schema": {
+              "title": "Page Limit",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "Sets a numerical limit on the number of entries returned.\nSee [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-pagination).\nThe API implementation MUST return no more than the number specified.\nIt MAY return fewer.\nThe database MAY have a maximum limit and not accept larger numbers (in which case an error code -- 403 Forbidden -- MUST be returned).\nThe default limit value is up to the API implementation to decide.\nExample: `http://example.com/optimade/v1/structures?page_limit=100`",
+              "default": 20
+            },
+            "name": "page_limit",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+            "required": false,
+            "schema": {
+              "title": "Page Offset",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _offset-based_ pagination: using `page_offset` and `page_limit` is RECOMMENDED.\nExample: Skip 50 structures and fetch up to 100: `/structures?page_offset=50&page_limit=100`.",
+              "default": 0
+            },
+            "name": "page_offset",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`.",
+            "required": false,
+            "schema": {
+              "title": "Page Number",
+              "type": "integer",
+              "description": "RECOMMENDED for use with _page-based_ pagination: using `page_number` and `page_limit` is RECOMMENDED.\nIt is RECOMMENDED that the first page has number 1, i.e., that `page_number` is 1-based.\nExample: Fetch page 2 of up to 50 structures per page: `/structures?page_number=2&page_limit=50`."
+            },
+            "name": "page_number",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+            "required": false,
+            "schema": {
+              "title": "Page Cursor",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _cursor-based_ pagination: using `page_cursor` and `page_limit` is RECOMMENDED.",
+              "default": 0
+            },
+            "name": "page_cursor",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+            "required": false,
+            "schema": {
+              "title": "Page Above",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.\nExample: Fetch up to 100 structures above sort-field value 4000 (in this example, server chooses to fetch results sorted by increasing `id`, so `page_above` value refers to an `id` value): `/structures?page_above=4000&page_limit=100`.",
+              "default": 0
+            },
+            "name": "page_above",
+            "in": "query"
+          },
+          {
+            "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+            "required": false,
+            "schema": {
+              "title": "Page Below",
+              "minimum": 0.0,
+              "type": "integer",
+              "description": "RECOMMENDED for use with _value-based_ pagination: using `page_above`/`page_below` and `page_limit` is RECOMMENDED.",
+              "default": 0
+            },
+            "name": "page_below",
+            "in": "query"
+          },
+          {
+            "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+            "required": false,
+            "schema": {
+              "title": "Include",
+              "type": "string",
+              "description": "A server MAY implement the JSON API concept of returning [compound documents](https://jsonapi.org/format/1.0/#document-compound-documents) by utilizing the `include` query parameter as specified by [JSON API 1.0](https://jsonapi.org/format/1.0/#fetching-includes).\n\nAll related resource objects MUST be returned as part of an array value for the top-level `included` field, see the section JSON Response Schema: Common Fields.\n\nThe value of `include` MUST be a comma-separated list of \"relationship paths\", as defined in the [JSON API](https://jsonapi.org/format/1.0/#fetching-includes).\nIf relationship paths are not supported, or a server is unable to identify a relationship path a `400 Bad Request` response MUST be made.\n\nThe **default value** for `include` is `references`.\nThis means `references` entries MUST always be included under the top-level field `included` as default, since a server assumes if `include` is not specified by a client in the request, it is still specified as `include=references`.\nNote, if a client explicitly specifies `include` and leaves out `references`, `references` resource objects MUST NOT be included under the top-level field `included`, as per the definition of `included`, see section JSON Response Schema: Common Fields.\n\n> **Note**: A query with the parameter `include` set to the empty string means no related resource objects are to be returned under the top-level field `included`.",
+              "default": "references"
+            },
+            "name": "include",
+            "in": "query"
+          },
+          {
+            "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+            "required": false,
+            "schema": {
+              "title": "Api Hint",
+              "pattern": "(v[0-9]+(\\.[0-9]+)?)?",
+              "type": "string",
+              "description": "If the client provides the parameter, the value SHOULD have the format `vMAJOR` or `vMAJOR.MINOR`, where MAJOR is a major version and MINOR is a minor version of the API. For example, if a client appends `api_hint=v1.0` to the query string, the hint provided is for major version 1 and minor version 0.",
+              "default": ""
+            },
+            "name": "api_hint",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LinksResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "Not Implemented",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "553": {
+            "description": "Version Not Supported",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/versions": {
+      "get": {
+        "tags": [
+          "Versions"
+        ],
+        "summary": "Get Versions",
+        "description": "Respond with the text/csv representation for the served versions.",
+        "operationId": "get_versions_versions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/csv; header=present": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Aggregate": {
+        "title": "Aggregate",
+        "enum": [
+          "ok",
+          "test",
+          "staging",
+          "no"
+        ],
+        "description": "Enumeration of aggregate values"
+      },
+      "Attributes": {
+        "title": "Attributes",
+        "type": "object",
+        "properties": {},
+        "description": "Members of the attributes object (\"attributes\") represent information about the resource object in which it's defined.\nThe keys for Attributes MUST NOT be:\n    relationships\n    links\n    id\n    type"
+      },
+      "AvailableApiVersion": {
+        "title": "AvailableApiVersion",
+        "required": [
+          "url",
+          "version"
+        ],
+        "type": "object",
+        "properties": {
+          "url": {
+            "title": "Url",
+            "maxLength": 65536,
+            "minLength": 1,
+            "pattern": ".+/v[0-1](\\.[0-9]+)*/?$",
+            "type": "string",
+            "description": "A string specifying a versioned base URL that MUST adhere to the rules in section Base URL",
+            "format": "uri"
+          },
+          "version": {
+            "title": "Version",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+            "type": "string",
+            "description": "A string containing the full version number of the API served at that versioned base URL.\nThe version number string MUST NOT be prefixed by, e.g., 'v'.\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "example": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
+          }
+        },
+        "description": "A JSON object containing information about an available API version"
+      },
+      "BaseRelationshipMeta": {
+        "title": "BaseRelationshipMeta",
+        "required": [
+          "description"
+        ],
+        "type": "object",
+        "properties": {
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "OPTIONAL human-readable description of the relationship."
+          }
+        },
+        "description": "Specific meta field for base relationship resource"
+      },
+      "BaseRelationshipResource": {
+        "title": "BaseRelationshipResource",
+        "required": [
+          "id",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "Resource ID"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "Resource type"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseRelationshipMeta"
+              }
+            ],
+            "description": "Relationship meta field. MUST contain 'description' if supplied."
+          }
+        },
+        "description": "Minimum requirements to represent a relationship resource"
+      },
+      "EntryRelationships": {
+        "title": "EntryRelationships",
+        "type": "object",
+        "properties": {
+          "references": {
+            "title": "References",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ReferenceRelationship"
+              }
+            ],
+            "description": "Object containing links to relationships with entries of the `references` type."
+          },
+          "structures": {
+            "title": "Structures",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StructureRelationship"
+              }
+            ],
+            "description": "Object containing links to relationships with entries of the `structures` type."
+          }
+        },
+        "description": "This model wraps the JSON API Relationships to include type-specific top level keys."
+      },
+      "EntryResource": {
+        "title": "EntryResource",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "The name of the type of an entry.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n    - MUST be an existing entry type.\n    - The entry of type `<type>` and ID `<id>` MUST be returned in response to a request for `/<type>/<id>` under the versioned base URL.\n\n- **Example**: `\"structures\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "title": "Attributes",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryResourceAttributes"
+              }
+            ],
+            "description": "A dictionary, containing key-value pairs representing the entry's properties, except for `type` and `id`.\nDatabase-provider-specific properties need to include the database-provider-specific prefix (see section on Database-Provider-Specific Namespace Prefixes)."
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryRelationships"
+              }
+            ],
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
+          }
+        },
+        "description": "The base model for an entry resource."
+      },
+      "EntryResourceAttributes": {
+        "title": "EntryResourceAttributes",
+        "required": [
+          "last_modified"
+        ],
+        "type": "object",
+        "properties": {
+          "immutable_id": {
+            "title": "Immutable Id",
+            "type": "string",
+            "description": "The entry's immutable ID (e.g., an UUID). This is important for databases having preferred IDs that point to \"the latest version\" of a record, but still offer access to older variants. This ID maps to the version-specific record, in case it changes in the future.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: OPTIONAL support in implementations, i.e., MAY be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n\n- **Examples**:\n    - `\"8bd3e750-b477-41a0-9b11-3a799f21b44f\"`\n    - `\"fjeiwoj,54;@=%<>#32\"` (Strings that are not URL-safe are allowed.)",
+            "x-optimade-support": "optional",
+            "x-optimade-queryable": "must"
+          },
+          "last_modified": {
+            "title": "Last Modified",
+            "type": "string",
+            "description": "Date and time representing when the entry was last modified.\n\n- **Type**: timestamp.\n\n- **Requirements/Conventions**:\n    - **Support**: SHOULD be supported by all implementations, i.e., SHOULD NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response unless the query parameter `response_fields` is present and does not include this property.\n\n- **Example**:\n    - As part of JSON response format: `\"2007-04-05T14:30:20Z\"` (i.e., encoded as an [RFC 3339 Internet Date/Time Format](https://tools.ietf.org/html/rfc3339#section-5.6) string.)",
+            "format": "date-time",
+            "x-optimade-support": "should",
+            "x-optimade-queryable": "must"
+          }
+        },
+        "description": "Contains key-value pairs representing the entry's properties."
+      },
+      "Error": {
+        "title": "Error",
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string",
+            "description": "the HTTP status code applicable to this problem, expressed as a string value."
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          }
+        },
+        "description": "An error response"
+      },
+      "ErrorLinks": {
+        "title": "ErrorLinks",
+        "type": "object",
+        "properties": {
+          "about": {
+            "title": "About",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A link that leads to further details about this particular occurrence of the problem."
+          }
+        },
+        "description": "A Links object specific to Error objects"
+      },
+      "ErrorResponse": {
+        "title": "ErrorResponse",
+        "required": [
+          "meta",
+          "errors"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Resource"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Resource"
+                }
+              }
+            ],
+            "description": "Outputted Data"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information."
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OptimadeError"
+            },
+            "description": "A list of OPTIMADE-specific JSON API error objects, where the field detail MUST be present."
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            },
+            "description": "A list of unique included resources"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors MUST be present and data MUST be skipped"
+      },
+      "ErrorSource": {
+        "title": "ErrorSource",
+        "type": "object",
+        "properties": {
+          "pointer": {
+            "title": "Pointer",
+            "type": "string",
+            "description": "a JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \"/data\" for a primary data object, or \"/data/attributes/title\" for a specific attribute]."
+          },
+          "parameter": {
+            "title": "Parameter",
+            "type": "string",
+            "description": "a string indicating which URI query parameter caused the error."
+          }
+        },
+        "description": "an object containing references to the source of the error"
+      },
+      "Implementation": {
+        "title": "Implementation",
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "name of the implementation"
+          },
+          "version": {
+            "title": "Version",
+            "type": "string",
+            "description": "version string of the current implementation"
+          },
+          "homepage": {
+            "title": "Homepage",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the homepage of the implementation."
+          },
+          "source_url": {
+            "title": "Source Url",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation source, either downloadable archive or version control system."
+          },
+          "maintainer": {
+            "title": "Maintainer",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImplementationMaintainer"
+              }
+            ],
+            "description": "A dictionary providing details about the maintainer of the implementation."
+          },
+          "issue_tracker": {
+            "title": "Issue Tracker",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) pointing to the implementation's issue tracker."
+          }
+        },
+        "description": "Information on the server implementation"
+      },
+      "ImplementationMaintainer": {
+        "title": "ImplementationMaintainer",
+        "required": [
+          "email"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "title": "Email",
+            "type": "string",
+            "description": "the maintainer's email address",
+            "format": "email"
+          }
+        },
+        "description": "Details about the maintainer of the implementation"
+      },
+      "IndexInfoAttributes": {
+        "title": "IndexInfoAttributes",
+        "required": [
+          "api_version",
+          "available_api_versions",
+          "available_endpoints",
+          "entry_types_by_format"
+        ],
+        "type": "object",
+        "properties": {
+          "api_version": {
+            "title": "Api Version",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+            "type": "string",
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "example": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
+          },
+          "available_api_versions": {
+            "title": "Available Api Versions",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvailableApiVersion"
+            },
+            "description": "A list of dictionaries of available API versions at other base URLs"
+          },
+          "formats": {
+            "title": "Formats",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of available output formats.",
+            "default": [
+              "json"
+            ]
+          },
+          "available_endpoints": {
+            "title": "Available Endpoints",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of available endpoints (i.e., the string to be appended to the versioned base URL)."
+          },
+          "entry_types_by_format": {
+            "title": "Entry Types By Format",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "Available entry endpoints as a function of output formats."
+          },
+          "is_index": {
+            "title": "Is Index",
+            "type": "boolean",
+            "description": "This must be `true` since this is an index meta-database (see section Index Meta-Database).",
+            "default": true
+          }
+        },
+        "description": "Attributes for Base URL Info endpoint for an Index Meta-Database"
+      },
+      "IndexInfoResource": {
+        "title": "IndexInfoResource",
+        "required": [
+          "id",
+          "type",
+          "attributes",
+          "relationships"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "pattern": "^/$",
+            "type": "string",
+            "default": "/"
+          },
+          "type": {
+            "title": "Type",
+            "pattern": "^info$",
+            "type": "string",
+            "default": "info"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/IndexInfoAttributes"
+          },
+          "relationships": {
+            "title": "Relationships",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/IndexRelationship"
+            },
+            "description": "Reference to the Links identifier object under the `links` endpoint that the provider has chosen as their 'default' OPTIMADE API database.\nA client SHOULD present this database as the first choice when an end-user chooses this provider."
+          }
+        },
+        "description": "Index Meta-Database Base URL Info endpoint resource"
+      },
+      "IndexInfoResponse": {
+        "title": "IndexInfoResponse",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IndexInfoResource"
+              }
+            ],
+            "description": "Index meta-database /info data."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "description": "A list of unique errors"
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            },
+            "description": "A list of unique included resources"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
+      "IndexRelationship": {
+        "title": "IndexRelationship",
+        "required": [
+          "data"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RelatedLinksResource"
+              }
+            ],
+            "description": "[JSON API resource linkage](http://jsonapi.org/format/1.0/#document-links).\nIt MUST be either `null` or contain a single Links identifier object with the fields `id` and `type`"
+          }
+        },
+        "description": "Index Meta-Database relationship"
+      },
+      "JsonApi": {
+        "title": "JsonApi",
+        "type": "object",
+        "properties": {
+          "version": {
+            "title": "Version",
+            "type": "string",
+            "description": "Version of the json API used",
+            "default": "1.0"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "Non-standard meta information"
+          }
+        },
+        "description": "An object describing the server's implementation"
+      },
+      "Link": {
+        "title": "Link",
+        "required": [
+          "href"
+        ],
+        "type": "object",
+        "properties": {
+          "href": {
+            "title": "Href",
+            "maxLength": 65536,
+            "minLength": 1,
+            "type": "string",
+            "description": "a string containing the link\u2019s URL.",
+            "format": "uri"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the link."
+          }
+        },
+        "description": "A link **MUST** be represented as either: a string containing the link's URL or a link object."
+      },
+      "LinkType": {
+        "title": "LinkType",
+        "enum": [
+          "child",
+          "root",
+          "external",
+          "providers"
+        ],
+        "description": "Enumeration of link_type values"
+      },
+      "LinksResource": {
+        "title": "LinksResource",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "An entry's ID as defined in section Definition of Terms.\n\n- **Type**: string.\n\n- **Requirements/Conventions**:\n    - **Support**: MUST be supported by all implementations, MUST NOT be `null`.\n    - **Query**: MUST be a queryable property with support for all mandatory filter features.\n    - **Response**: REQUIRED in the response.\n\n- **Examples**:\n    - `\"db/1234567\"`\n    - `\"cod/2000000\"`\n    - `\"cod/2000000@1234567\"`\n    - `\"nomad/L1234567890\"`\n    - `\"42\"`",
+            "x-optimade-support": "must",
+            "x-optimade-queryable": "must"
+          },
+          "type": {
+            "title": "Type",
+            "pattern": "^links$",
+            "type": "string",
+            "description": "These objects are described in detail in the section Links Endpoint",
+            "default": "links"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "title": "Attributes",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinksResourceAttributes"
+              }
+            ],
+            "description": "A dictionary containing key-value pairs representing the Links resource's properties."
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntryRelationships"
+              }
+            ],
+            "description": "A dictionary containing references to other entries according to the description in section Relationships encoded as [JSON API Relationships](https://jsonapi.org/format/1.0/#document-resource-object-relationships).\nThe OPTIONAL human-readable description of the relationship MAY be provided in the `description` field inside the `meta` dictionary of the JSON API resource identifier object."
+          }
+        },
+        "description": "A Links endpoint resource object"
+      },
+      "LinksResourceAttributes": {
+        "title": "LinksResourceAttributes",
+        "required": [
+          "name",
+          "description",
+          "base_url",
+          "homepage",
+          "link_type"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "Human-readable name for the OPTIMADE API implementation, e.g., for use in clients to show the name to the end-user."
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "Human-readable description for the OPTIMADE API implementation, e.g., for use in clients to show a description to the end-user."
+          },
+          "base_url": {
+            "title": "Base Url",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "JSON API links object, pointing to the base URL for this implementation"
+          },
+          "homepage": {
+            "title": "Homepage",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "JSON API links object, pointing to a homepage URL for this implementation"
+          },
+          "link_type": {
+            "title": "Link Type",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LinkType"
+              }
+            ],
+            "description": "The type of the linked relation.\nMUST be one of these values: 'child', 'root', 'external', 'providers'."
+          },
+          "aggregate": {
+            "title": "Aggregate",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Aggregate"
+              }
+            ],
+            "description": "A string indicating whether a client that is following links to aggregate results from different OPTIMADE implementations should follow this link or not.\nThis flag SHOULD NOT be indicated for links where `link_type` is not `child`.\n\nIf not specified, clients MAY assume that the value is `ok`.\nIf specified, and the value is anything different than `ok`, the client MUST assume that the server is suggesting not to follow the link during aggregation by default (also if the value is not among the known ones, in case a future specification adds new accepted values).\n\nSpecific values indicate the reason why the server is providing the suggestion.\nA client MAY follow the link anyway if it has reason to do so (e.g., if the client is looking for all test databases, it MAY follow the links marked with `aggregate`=`test`).\n\nIf specified, it MUST be one of the values listed in section Link Aggregate Options.",
+            "default": "ok"
+          },
+          "no_aggregate_reason": {
+            "title": "No Aggregate Reason",
+            "type": "string",
+            "description": "An OPTIONAL human-readable string indicating the reason for suggesting not to aggregate results following the link.\nIt SHOULD NOT be present if `aggregate`=`ok`."
+          }
+        },
+        "description": "Links endpoint resource object attributes"
+      },
+      "LinksResponse": {
+        "title": "LinksResponse",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "title": "Data",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/LinksResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ],
+            "description": "List of unique OPTIMADE links resource objects."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMeta"
+              }
+            ],
+            "description": "A meta object containing non-standard information"
+          },
+          "errors": {
+            "title": "Errors",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "description": "A list of unique errors"
+          },
+          "included": {
+            "title": "Included",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EntryResource"
+                }
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            ]
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToplevelLinks"
+              }
+            ],
+            "description": "Links associated with the primary data or errors"
+          },
+          "jsonapi": {
+            "title": "Jsonapi",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonApi"
+              }
+            ],
+            "description": "Information about the JSON API used"
+          }
+        },
+        "description": "errors are not allowed"
+      },
+      "Meta": {
+        "title": "Meta",
+        "type": "object",
+        "properties": {},
+        "description": "Non-standard meta-information that can not be represented as an attribute or relationship."
+      },
+      "OptimadeError": {
+        "title": "OptimadeError",
+        "required": [
+          "detail"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string",
+            "description": "the HTTP status code applicable to this problem, expressed as a string value."
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          }
+        },
+        "description": "detail MUST be present"
+      },
+      "Provider": {
+        "title": "Provider",
+        "required": [
+          "name",
+          "description",
+          "prefix"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "a short name for the database provider"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string",
+            "description": "a longer description of the database provider"
+          },
+          "prefix": {
+            "title": "Prefix",
+            "pattern": "^[a-z]([a-z]|[0-9]|_)*$",
+            "type": "string",
+            "description": "database-provider-specific prefix as found in section Database-Provider-Specific Namespace Prefixes."
+          },
+          "homepage": {
+            "title": "Homepage",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "a [JSON API links object](http://jsonapi.org/format/1.0#document-links) pointing to homepage of the database provider, either directly as a string, or as a link object."
+          }
+        },
+        "description": "Information on the database provider of the implementation."
+      },
+      "ReferenceRelationship": {
+        "title": "ReferenceRelationship",
+        "type": "object",
+        "properties": {
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RelationshipLinks"
+              }
+            ],
+            "description": "a links object containing at least one of the following: self, related"
+          },
+          "data": {
+            "title": "Data",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BaseRelationshipResource"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BaseRelationshipResource"
+                }
+              }
+            ],
+            "description": "Resource linkage"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object that contains non-standard meta-information about the relationship."
+          }
+        },
+        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."
+      },
+      "RelatedLinksResource": {
+        "title": "RelatedLinksResource",
+        "required": [
+          "id",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "Resource ID"
+          },
+          "type": {
+            "title": "Type",
+            "pattern": "^links$",
+            "type": "string",
+            "default": "links"
+          }
+        },
+        "description": "A related Links resource object"
+      },
+      "RelationshipLinks": {
+        "title": "RelationshipLinks",
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "Self",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A link for the relationship itself (a 'relationship link').\nThis link allows the client to directly manipulate the relationship.\nWhen fetched successfully, this link returns the [linkage](https://jsonapi.org/format/1.0/#document-resource-object-linkage) for the related resources as its primary data.\n(See [Fetching Relationships](https://jsonapi.org/format/1.0/#fetching-relationships).)"
+          },
+          "related": {
+            "title": "Related",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A [related resource link](https://jsonapi.org/format/1.0/#document-resource-object-related-resource-links)."
+          }
+        },
+        "description": "A resource object **MAY** contain references to other resource objects (\"relationships\").\nRelationships may be to-one or to-many.\nRelationships can be specified by including a member in a resource's links object."
+      },
+      "Relationships": {
+        "title": "Relationships",
+        "type": "object",
+        "properties": {},
+        "description": "Members of the relationships object (\"relationships\") represent references from the resource object in which it's defined to other resource objects.\nKeys MUST NOT be:\n    type\n    id"
+      },
+      "Resource": {
+        "title": "Resource",
+        "required": [
+          "id",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "Resource ID"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "description": "Resource type"
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceLinks"
+              }
+            ],
+            "description": "a links object containing links related to the resource."
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship."
+          },
+          "attributes": {
+            "title": "Attributes",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Attributes"
+              }
+            ],
+            "description": "an attributes object representing some of the resource\u2019s data."
+          },
+          "relationships": {
+            "title": "Relationships",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Relationships"
+              }
+            ],
+            "description": "[Relationships object](https://jsonapi.org/format/1.0/#document-resource-object-relationships)\ndescribing relationships between the resource and other JSON API resources."
+          }
+        },
+        "description": "Resource objects appear in a JSON API document to represent resources."
+      },
+      "ResourceLinks": {
+        "title": "ResourceLinks",
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "Self",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A link that identifies the resource represented by the resource object."
+          }
+        },
+        "description": "A Resource Links object"
+      },
+      "ResponseMeta": {
+        "title": "ResponseMeta",
+        "required": [
+          "query",
+          "api_version",
+          "more_data_available"
+        ],
+        "type": "object",
+        "properties": {
+          "query": {
+            "title": "Query",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseMetaQuery"
+              }
+            ],
+            "description": "Information on the Query that was requested"
+          },
+          "api_version": {
+            "title": "Api Version",
+            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+            "type": "string",
+            "description": "Presently used full version of the OPTIMADE API.\nThe version number string MUST NOT be prefixed by, e.g., \"v\".\nExamples: `1.0.0`, `1.0.0-rc.2`.",
+            "example": [
+              "0.10.1",
+              "1.0.0-rc.2",
+              "1.2.3-rc.5+develop"
+            ]
+          },
+          "more_data_available": {
+            "title": "More Data Available",
+            "type": "boolean",
+            "description": "`false` if the response contains all data for the request (e.g., a request issued to a single entry endpoint, or a `filter` query at the last page of a paginated response) and `true` if the response is incomplete in the sense that multiple objects match the request, and not all of them have been included in the response (e.g., a query with multiple pages that is not at the last page)."
+          },
+          "schema": {
+            "title": "Schema",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) that points to a schema for the response.\nIf it is a string, or a dictionary containing no `meta` field, the provided URL MUST point at an [OpenAPI](https://swagger.io/specification/) schema.\nIt is possible that future versions of this specification allows for alternative schema types.\nHence, if the `meta` field of the JSON API links object is provided and contains a field `schema_type` that is not equal to the string `OpenAPI` the client MUST not handle failures to parse the schema or to validate the response against the schema as errors."
+          },
+          "time_stamp": {
+            "title": "Time Stamp",
+            "type": "string",
+            "description": "A timestamp containing the date and time at which the query was executed.",
+            "format": "date-time"
+          },
+          "data_returned": {
+            "title": "Data Returned",
+            "minimum": 0.0,
+            "type": "integer",
+            "description": "An integer containing the total number of data resource objects returned for the current `filter` query, independent of pagination."
+          },
+          "provider": {
+            "title": "Provider",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Provider"
+              }
+            ],
+            "description": "information on the database provider of the implementation."
+          },
+          "data_available": {
+            "title": "Data Available",
+            "type": "integer",
+            "description": "An integer containing the total number of data resource objects available in the database for the endpoint."
+          },
+          "last_id": {
+            "title": "Last Id",
+            "type": "string",
+            "description": "a string containing the last ID returned"
+          },
+          "response_message": {
+            "title": "Response Message",
+            "type": "string",
+            "description": "response string from the server"
+          },
+          "implementation": {
+            "title": "Implementation",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Implementation"
+              }
+            ],
+            "description": "a dictionary describing the server implementation"
+          },
+          "warnings": {
+            "title": "Warnings",
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Warnings"
+            },
+            "description": "A list of warning resource objects representing non-critical errors or warnings.\nA warning resource object is defined similarly to a [JSON API error object](http://jsonapi.org/format/1.0/#error-objects), but MUST also include the field `type`, which MUST have the value `\"warning\"`.\nThe field `detail` MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\nThe field `status`, representing a HTTP response status code, MUST NOT be present for a warning resource object.\nThis is an exclusive field for error resource objects."
+          }
+        },
+        "description": "A [JSON API meta member](https://jsonapi.org/format/1.0#document-meta)\nthat contains JSON API meta objects of non-standard\nmeta-information.\n\nOPTIONAL additional information global to the query that is not\nspecified in this document, MUST start with a\ndatabase-provider-specific prefix."
+      },
+      "ResponseMetaQuery": {
+        "title": "ResponseMetaQuery",
+        "required": [
+          "representation"
+        ],
+        "type": "object",
+        "properties": {
+          "representation": {
+            "title": "Representation",
+            "type": "string",
+            "description": "A string with the part of the URL following the versioned or unversioned base URL that serves the API.\nQuery parameters that have not been used in processing the request MAY be omitted.\nIn particular, if no query parameters have been involved in processing the request, the query part of the URL MAY be excluded.\nExample: `/structures?filter=nelements=2`"
+          }
+        },
+        "description": "Information on the query that was requested."
+      },
+      "StructureRelationship": {
+        "title": "StructureRelationship",
+        "type": "object",
+        "properties": {
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RelationshipLinks"
+              }
+            ],
+            "description": "a links object containing at least one of the following: self, related"
+          },
+          "data": {
+            "title": "Data",
+            "uniqueItems": true,
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BaseRelationshipResource"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BaseRelationshipResource"
+                }
+              }
+            ],
+            "description": "Resource linkage"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object that contains non-standard meta-information about the relationship."
+          }
+        },
+        "description": "Similar to normal JSON API relationship, but with addition of OPTIONAL meta field for a resource."
+      },
+      "ToplevelLinks": {
+        "title": "ToplevelLinks",
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "Self",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A link to itself"
+          },
+          "related": {
+            "title": "Related",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "A related resource link"
+          },
+          "first": {
+            "title": "First",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The first page of data"
+          },
+          "last": {
+            "title": "Last",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The last page of data"
+          },
+          "prev": {
+            "title": "Prev",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The previous page of data"
+          },
+          "next": {
+            "title": "Next",
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              },
+              {
+                "$ref": "#/components/schemas/Link"
+              }
+            ],
+            "description": "The next page of data"
+          }
+        },
+        "description": "A set of Links objects, possibly including pagination"
+      },
+      "Warnings": {
+        "title": "Warnings",
+        "required": [
+          "detail",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "A unique identifier for this particular occurrence of the problem."
+          },
+          "links": {
+            "title": "Links",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorLinks"
+              }
+            ],
+            "description": "A links object storing about"
+          },
+          "code": {
+            "title": "Code",
+            "type": "string",
+            "description": "an application-specific error code, expressed as a string value."
+          },
+          "title": {
+            "title": "Title",
+            "type": "string",
+            "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization."
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence of the problem."
+          },
+          "source": {
+            "title": "Source",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ErrorSource"
+              }
+            ],
+            "description": "An object containing references to the source of the error"
+          },
+          "meta": {
+            "title": "Meta",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ],
+            "description": "a meta object containing non-standard meta-information about the error."
+          },
+          "type": {
+            "title": "Type",
+            "pattern": "^warning$",
+            "type": "string",
+            "description": "Warnings must be of type \"warning\"",
+            "default": "warning"
+          }
+        },
+        "description": "OPTIMADE-specific warning class based on OPTIMADE-specific JSON API Error.\n\nFrom the specification:\n\nA warning resource object is defined similarly to a JSON API error object, but MUST also include the field type, which MUST have the value \"warning\".\nThe field detail MUST be present and SHOULD contain a non-critical message, e.g., reporting unrecognized search attributes or deprecated features.\n\nNote: Must be named \"Warnings\", since \"Warning\" is a built-in Python class."
+      }
+    }
+  }
+}

--- a/openapi/v1.2.0/optimade_index.json
+++ b/openapi/v1.2.0/optimade_index.json
@@ -2,8 +2,8 @@
   "openapi": "3.0.2",
   "info": {
     "title": "OPTIMADE API - Index meta-database",
-    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.19.5) v0.19.5.",
-    "version": "1.1.0"
+    "description": "The [Open Databases Integration for Materials Design (OPTIMADE) consortium](https://www.optimade.org/) aims to make materials databases interoperational by developing a common REST API.\nThis is the \"special\" index meta-database.\n\nThis specification is generated using [`optimade-python-tools`](https://github.com/Materials-Consortia/optimade-python-tools/tree/v0.20.1) v0.21.0~develop.",
+    "version": "1.2.0~develop"
   },
   "paths": {
     "/info": {
@@ -846,7 +846,9 @@
           "api_version",
           "available_api_versions",
           "available_endpoints",
-          "entry_types_by_format"
+          "entry_types_by_format",
+          "license",
+          "available_licenses"
         ],
         "type": "object",
         "properties": {
@@ -898,6 +900,29 @@
               }
             },
             "description": "Available entry endpoints as a function of output formats."
+          },
+          "license": {
+            "title": "License",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Link"
+              },
+              {
+                "maxLength": 65536,
+                "minLength": 1,
+                "type": "string",
+                "format": "uri"
+              }
+            ],
+            "description": "A [JSON API links object](http://jsonapi.org/format/1.0/#document-links) giving a URL to a web page containing a human-readable text describing the license (or licensing options if there are multiple) covering all the data and metadata provided by this database.\nClients are advised not to try automated parsing of this link or its content, but rather rely on the field `available_licenses` instead."
+          },
+          "available_licenses": {
+            "title": "Available Licenses",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of [SPDX license identifiers](https://spdx.org/licenses/) specifying a set of alternative licenses under which the client is granted access to all the data and metadata in this database.\n\nIf the data and metadata is available under multiple alternative licenses, identifiers of these multiple licenses SHOULD be provided to let clients know under which conditions the data and metadata can be used.\nInclusion of a license identifier in the list is a commitment of the database that the rights are in place to grant clients access to all the data and metadata according to the terms of either of these licenses (at the choice of the client).\nIf the licensing information provided via the field `license` omits licensing options specified in `available_licenses`, or if it otherwise contradicts them, a client MUST still be allowed to interpret the inclusion of a license in `available_licenses` as a full commitment from the database that the data and metadata is available, without exceptions, under the respective licenses.\nIf the database cannot make that commitment, e.g., if only part of the data is available under a license, the corresponding license identifier MUST NOT appear in `available_licenses` (but, rather, the field `license` is to be used to clarify the licensing situation.)\nAn empty list indicates that none of the SPDX licenses apply for the entirety of the database and that the licensing situation is clarified in human readable form in the field `license`."
           },
           "is_index": {
             "title": "Is Index",
@@ -1709,6 +1734,12 @@
             "title": "Response Message",
             "type": "string",
             "description": "response string from the server"
+          },
+          "request_delay": {
+            "title": "Request Delay",
+            "minimum": 0.0,
+            "type": "number",
+            "description": "A non-negative float giving time in seconds that the client is suggested to wait before issuing a subsequent request."
           },
           "implementation": {
             "title": "Implementation",


### PR DESCRIPTION
This PR adds draft schemas for v1.2.0 by applying them as patches to v1.1.0 for a somewhat intelligible diff.

This PR is blocked by many things, like #8, the release of the v1.2 spec, fixing the schemas in optimade-python-tools etc... but may be a useful start for discussions. See also similar PRs:

- Development of v1.2 in optimade-python-tools that were used to generate this schema version https://github.com/Materials-Consortia/optimade-python-tools/pull/1427
- Updating the schemas in the spec repo with the same changes https://github.com/Materials-Consortia/optimade-python-tools/pull/1427